### PR TITLE
indexer: export sinks as separate modules

### DIFF
--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -6,7 +6,8 @@
   "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./plugins": "./src/plugins/index.ts"
+    "./plugins": "./src/plugins/index.ts",
+    "./sinks/sqlite": "./src/sinks/sqlite.ts"
   },
   "publishConfig": {
     "files": ["dist", "src", "README.md"],
@@ -17,6 +18,11 @@
         "types": "./dist/index.d.ts",
         "import": "./dist/index.mjs",
         "default": "./dist/index.mjs"
+      },
+      "./sinks/sqlite": {
+        "types": "./dist/sinks/sqlite.d.ts",
+        "import": "./dist/sinks/sqlite.mjs",
+        "default": "./dist/sinks/sqlite.mjs"
       }
     }
   },

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -1,6 +1,5 @@
 export * from "./indexer";
 export * from "./sink";
-export * from "./sinks";
 export { useIndexerContext } from "./context";
 
 export * from "./plugins";

--- a/packages/indexer/src/sinks/index.ts
+++ b/packages/indexer/src/sinks/index.ts
@@ -1,1 +1,0 @@
-export * from "./sqlite";


### PR DESCRIPTION
Export all sinks as separate modules to avoid users importing peer dependencies
even when not used.
