### PR TITLE
indexer: sink rfc

### DIFF
--- a/examples/indexer/package.json
+++ b/examples/indexer/package.json
@@ -23,6 +23,8 @@
     "citty": "^0.1.6",
     "consola": "^3.2.3",
     "csv-stringify": "^6.5.0",
+    "drizzle-orm": "^0.33.0",
+    "postgres": "^3.4.4",
     "viem": "^2.12.4"
   },
   "devDependencies": {

--- a/examples/starknet-indexer/package.json
+++ b/examples/starknet-indexer/package.json
@@ -22,6 +22,8 @@
     "citty": "^0.1.6",
     "consola": "^3.2.3",
     "csv-stringify": "^6.5.0",
+    "drizzle-orm": "^0.33.0",
+    "postgres": "^3.4.4",
     "sqlite": "^5.1.1",
     "viem": "^2.12.4"
   },

--- a/examples/starknet-indexer/src/main.ts
+++ b/examples/starknet-indexer/src/main.ts
@@ -14,7 +14,7 @@ const command = defineCommand({
   args: {
     stream: {
       type: "string",
-      default: "http://127.0.0.1:7007",
+      default: "http://mainnet-v2.starknet.a5a.ch:7007",
       description: "Starknet stream URL",
     },
     authToken: {

--- a/packages/cli/playground/indexers/starknet.indexer.ts
+++ b/packages/cli/playground/indexers/starknet.indexer.ts
@@ -23,19 +23,11 @@ export default function indexer(runtimeConfig: ApibaraRuntimeConfig) {
       ],
     },
     async transform({ block: { header, events } }) {
-      return [
-        {
-          blockNumber: header.blockNumber,
-          events,
-        },
-      ];
+      consola.info("Transforming block ", header?.blockNumber);
     },
     hooks: {
-      "sink:write"({ data }) {
-        consola.log("Wrote:", data[0].events.length, "Tranfer events");
-      },
-      "sink:flush"({ endCursor }) {
-        consola.log("Flushing", endCursor.orderKey);
+      "handler:after": ({ endCursor }) => {
+        consola.info("Handler After ", endCursor?.orderKey);
       },
     },
   });

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -9,6 +9,7 @@
     "./plugins": "./src/plugins/index.ts",
     "./sinks/sqlite": "./src/sinks/sqlite.ts",
     "./sinks/csv": "./src/sinks/csv.ts",
+    "./sinks/drizzle": "./src/sinks/drizzle.ts",
     "./testing": "./src/testing/index.ts"
   },
   "publishConfig": {
@@ -34,6 +35,12 @@
         "require": "./dist/sinks/csv.cjs",
         "default": "./dist/sinks/csv.mjs"
       },
+      "./sinks/drizzle": {
+        "types": "./dist/sinks/drizzle.d.ts",
+        "import": "./dist/sinks/drizzle.mjs",
+        "require": "./dist/sinks/drizzle.cjs",
+        "default": "./dist/sinks/drizzle.mjs"
+      },
       "./testing": {
         "types": "./dist/testing/index.d.ts",
         "import": "./dist/testing/index.mjs",
@@ -56,6 +63,7 @@
     "@types/node": "^20.14.0",
     "better-sqlite3": "^11.1.2",
     "csv-stringify": "^6.5.0",
+    "drizzle-orm": "^0.33.0",
     "unbuild": "^2.0.0",
     "vitest": "^1.6.0"
   },
@@ -71,6 +79,7 @@
   "peerDependencies": {
     "better-sqlite3": "^11.1.2",
     "csv-stringify": "^6.5.0",
+    "drizzle-orm": "^0.33.0",
     "vitest": "^1.6.0"
   }
 }

--- a/packages/indexer/src/context.ts
+++ b/packages/indexer/src/context.ts
@@ -1,14 +1,19 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { getContext } from "unctx";
+import type { Sink } from "./sink";
 
 // biome-ignore lint/suspicious/noExplicitAny: context type
-export interface IndexerContext extends Record<string, any> {}
+export interface IndexerContext<TTxnParams = any> extends Record<string, any> {
+  sink?: Sink<TTxnParams>;
+  sinkTransaction?: TTxnParams;
+}
 
 export const indexerAsyncContext = getContext<IndexerContext>("indexer", {
   asyncContext: true,
   AsyncLocalStorage,
 });
 
-export function useIndexerContext() {
-  return indexerAsyncContext.use();
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+export function useIndexerContext<TTxnParams = any>() {
+  return indexerAsyncContext.use() as IndexerContext<TTxnParams>;
 }

--- a/packages/indexer/src/hooks/index.ts
+++ b/packages/indexer/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./useKVStore";
+export * from "./useSink";

--- a/packages/indexer/src/hooks/useSink.ts
+++ b/packages/indexer/src/hooks/useSink.ts
@@ -1,0 +1,9 @@
+import type { IndexerContext } from "../context";
+
+export function useSink<TTxnParams>({
+  context,
+}: {
+  context: IndexerContext<TTxnParams>;
+}) {
+  return context.sinkTransaction;
+}

--- a/packages/indexer/src/hooks/useSink.ts
+++ b/packages/indexer/src/hooks/useSink.ts
@@ -5,5 +5,9 @@ export function useSink<TTxnParams>({
 }: {
   context: IndexerContext<TTxnParams>;
 }) {
+  if (!context.sinkTransaction) {
+    throw new Error("Transaction context doesn't exist!");
+  }
+
   return context.sinkTransaction;
 }

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -4,3 +4,4 @@ export { useIndexerContext } from "./context";
 
 export * from "./plugins";
 export * from "./vcr";
+export * from "./hooks";

--- a/packages/indexer/src/plugins/config.ts
+++ b/packages/indexer/src/plugins/config.ts
@@ -1,11 +1,11 @@
 import type { Indexer } from "../indexer";
 
-export type IndexerPlugin<TFilter, TBlock, TRet> = (
-  indexer: Indexer<TFilter, TBlock, TRet>,
+export type IndexerPlugin<TFilter, TBlock, TTxnParams> = (
+  indexer: Indexer<TFilter, TBlock, TTxnParams>,
 ) => void;
 
-export function defineIndexerPlugin<TFilter, TBlock, TRet>(
-  def: IndexerPlugin<TFilter, TBlock, TRet>,
+export function defineIndexerPlugin<TFilter, TBlock, TTxnParams>(
+  def: IndexerPlugin<TFilter, TBlock, TTxnParams>,
 ) {
   return def;
 }

--- a/packages/indexer/src/plugins/kv.ts
+++ b/packages/indexer/src/plugins/kv.ts
@@ -5,10 +5,10 @@ import { useIndexerContext } from "../context";
 import { deserialize, serialize } from "../vcr";
 import { defineIndexerPlugin } from "./config";
 
-export function kv<TFilter, TBlock, TRet>({
+export function kv<TFilter, TBlock, TTxnParams>({
   database,
 }: { database: SqliteDatabase }) {
-  return defineIndexerPlugin<TFilter, TBlock, TRet>((indexer) => {
+  return defineIndexerPlugin<TFilter, TBlock, TTxnParams>((indexer) => {
     indexer.hooks.hook("run:before", () => {
       KVStore.initialize(database);
     });

--- a/packages/indexer/src/plugins/persistence.test.ts
+++ b/packages/indexer/src/plugins/persistence.test.ts
@@ -9,7 +9,7 @@ import { klona } from "klona/full";
 import { describe, expect, it } from "vitest";
 import { run } from "../indexer";
 import { generateMockMessages } from "../testing";
-import { type MockRet, getMockIndexer } from "../testing/indexer";
+import { type MockTxnParams, getMockIndexer } from "../testing/indexer";
 import { SqlitePersistence, sqlitePersistence } from "./persistence";
 
 describe("Persistence", () => {
@@ -120,12 +120,14 @@ describe("Persistence", () => {
 
     const db = new Database(":memory:");
 
-    const persistence = sqlitePersistence<MockFilter, MockBlock, MockRet>({
-      database: db,
-    });
+    const persistence = sqlitePersistence<MockFilter, MockBlock, MockTxnParams>(
+      {
+        database: db,
+      },
+    );
 
     // create mock indexer with persistence plugin
-    const indexer = klona(getMockIndexer([persistence]));
+    const indexer = klona(getMockIndexer({ plugins: [persistence] }));
 
     await run(client, indexer);
 

--- a/packages/indexer/src/plugins/persistence.test.ts
+++ b/packages/indexer/src/plugins/persistence.test.ts
@@ -9,7 +9,7 @@ import { klona } from "klona/full";
 import { describe, expect, it } from "vitest";
 import { run } from "../indexer";
 import { generateMockMessages } from "../testing";
-import { type MockTxnParams, getMockIndexer } from "../testing/indexer";
+import { getMockIndexer } from "../testing/indexer";
 import { SqlitePersistence, sqlitePersistence } from "./persistence";
 
 describe("Persistence", () => {
@@ -120,14 +120,16 @@ describe("Persistence", () => {
 
     const db = new Database(":memory:");
 
-    const persistence = sqlitePersistence<MockFilter, MockBlock, MockTxnParams>(
-      {
-        database: db,
-      },
-    );
-
     // create mock indexer with persistence plugin
-    const indexer = klona(getMockIndexer({ plugins: [persistence] }));
+    const indexer = klona(
+      getMockIndexer({
+        plugins: [
+          sqlitePersistence({
+            database: db,
+          }),
+        ],
+      }),
+    );
 
     await run(client, indexer);
 

--- a/packages/indexer/src/plugins/persistence.ts
+++ b/packages/indexer/src/plugins/persistence.ts
@@ -27,7 +27,7 @@ export function sqlitePersistence<TFilter, TBlock, TTxnParams>({
       }
     });
 
-    indexer.hooks.hook("handler:after", ({ endCursor }) => {
+    indexer.hooks.hook("transaction:commit", ({ endCursor }) => {
       if (endCursor) {
         store.put({ cursor: endCursor });
       }

--- a/packages/indexer/src/plugins/persistence.ts
+++ b/packages/indexer/src/plugins/persistence.ts
@@ -3,10 +3,10 @@ import type { Database as SqliteDatabase, Statement } from "better-sqlite3";
 import { deserialize, serialize } from "../vcr";
 import { defineIndexerPlugin } from "./config";
 
-export function sqlitePersistence<TFilter, TBlock, TRet>({
+export function sqlitePersistence<TFilter, TBlock, TTxnParams>({
   database,
 }: { database: SqliteDatabase }) {
-  return defineIndexerPlugin<TFilter, TBlock, TRet>((indexer) => {
+  return defineIndexerPlugin<TFilter, TBlock, TTxnParams>((indexer) => {
     let store: SqlitePersistence<TFilter>;
 
     indexer.hooks.hook("run:before", () => {
@@ -27,7 +27,7 @@ export function sqlitePersistence<TFilter, TBlock, TRet>({
       }
     });
 
-    indexer.hooks.hook("sink:flush", ({ endCursor }) => {
+    indexer.hooks.hook("handler:after", ({ endCursor }) => {
       if (endCursor) {
         store.put({ cursor: endCursor });
       }

--- a/packages/indexer/src/sink.ts
+++ b/packages/indexer/src/sink.ts
@@ -1,36 +1,14 @@
-import type { Cursor, DataFinality } from "@apibara/protocol";
-import { Hookable } from "hookable";
-
 export type SinkData = Record<string, unknown>;
 
-export interface SinkEvents {
-  write({ data }: { data: SinkData[] }): void;
-  flush({
-    endCursor,
-    finality,
-  }: { endCursor?: Cursor; finality: DataFinality }): void;
+export abstract class Sink<TTxnParams = unknown> {
+  abstract transaction(
+    cb: (params: TTxnParams) => Promise<void>,
+  ): Promise<void>;
 }
 
-export type SinkWriteArgs = {
-  data: SinkData[];
-  cursor?: Cursor | undefined;
-  endCursor?: Cursor | undefined;
-  finality: DataFinality;
-};
-
-export abstract class Sink extends Hookable<SinkEvents> {
-  abstract write({
-    data,
-    cursor,
-    endCursor,
-    finality,
-  }: SinkWriteArgs): Promise<void>;
-}
-
-export class DefaultSink extends Sink {
-  async write({ data, endCursor, finality }: SinkWriteArgs) {
-    await this.callHook("write", { data });
-    await this.callHook("flush", { endCursor, finality });
+export class DefaultSink extends Sink<unknown> {
+  async transaction(cb: (params: unknown) => Promise<void>): Promise<void> {
+    await cb({});
   }
 }
 

--- a/packages/indexer/src/sinks/csv.test.ts
+++ b/packages/indexer/src/sinks/csv.test.ts
@@ -5,10 +5,11 @@ import {
   type MockFilter,
 } from "@apibara/protocol/testing";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useSink } from "../hooks";
 import { run } from "../indexer";
 import {} from "../plugins/persistence";
 import { generateMockMessages } from "../testing";
-import { type MockRet, getMockIndexer } from "../testing/indexer";
+import { getMockIndexer } from "../testing/indexer";
 import { csv } from "./csv";
 
 describe("Run Test", () => {
@@ -31,8 +32,20 @@ describe("Run Test", () => {
       return generateMockMessages();
     });
 
-    const sink = csv<MockRet>({ filepath: "test.csv" });
-    await run(client, getMockIndexer(), sink);
+    const sink = csv({ filepath: "test.csv" });
+    await run(
+      client,
+      getMockIndexer({
+        sink,
+        override: {
+          transform: async ({ context, endCursor, block: { data } }) => {
+            const { writer } = useSink({ context });
+            const insertHelper = writer(endCursor);
+            insertHelper.insert([{ data }]);
+          },
+        },
+      }),
+    );
 
     const csvData = await fs.readFile("test.csv", "utf-8");
 

--- a/packages/indexer/src/sinks/drizzle.ts
+++ b/packages/indexer/src/sinks/drizzle.ts
@@ -1,0 +1,83 @@
+import type {
+  ExtractTablesWithRelations,
+  TablesRelationalConfig,
+} from "drizzle-orm";
+import type {
+  PgDatabase,
+  PgQueryResultHKT,
+  PgTableWithColumns,
+  PgTransaction,
+  TableConfig,
+} from "drizzle-orm/pg-core";
+import { Sink } from "../sink";
+
+export type DrizzleSinkTables<
+  TTableConfig extends Record<string, TableConfig>,
+> = {
+  [K in keyof TTableConfig]: PgTableWithColumns<TTableConfig[K]>;
+};
+
+export type DrizzleSinkOptions<
+  TTableConfig extends Record<string, TableConfig>,
+  TQueryResult extends PgQueryResultHKT,
+  TFullSchema extends Record<string, unknown> = Record<string, never>,
+  TSchema extends
+    TablesRelationalConfig = ExtractTablesWithRelations<TFullSchema>,
+> = {
+  /**
+   * Database instance of drizzle-orm
+   */
+  database: PgDatabase<TQueryResult, TFullSchema, TSchema>;
+  /**
+   * The tables where data will be inserted.
+   */
+  tables: DrizzleSinkTables<TTableConfig>;
+};
+
+export class DrizzleSink<
+  TTableConfig extends Record<string, TableConfig>,
+  TQueryResult extends PgQueryResultHKT,
+  TFullSchema extends Record<string, unknown> = Record<string, never>,
+  TSchema extends
+    TablesRelationalConfig = ExtractTablesWithRelations<TFullSchema>,
+> extends Sink {
+  private _tables: DrizzleSinkTables<TTableConfig>;
+  private _db: PgDatabase<TQueryResult, TFullSchema, TSchema>;
+
+  constructor(
+    options: DrizzleSinkOptions<
+      TTableConfig,
+      TQueryResult,
+      TFullSchema,
+      TSchema
+    >,
+  ) {
+    super();
+    const { database, tables } = options;
+    this._tables = tables;
+    this._db = database;
+  }
+
+  async transaction(
+    cb: (params: {
+      db: PgTransaction<TQueryResult, TFullSchema, TSchema>;
+      tables: DrizzleSinkTables<TTableConfig>;
+    }) => Promise<void>,
+  ): Promise<void> {
+    await this._db.transaction(async (db) => {
+      await cb({ db, tables: this._tables });
+    });
+  }
+}
+
+export const drizzle = <
+  TTableConfig extends Record<string, TableConfig>,
+  TQueryResult extends PgQueryResultHKT,
+  TFullSchema extends Record<string, unknown> = Record<string, never>,
+  TSchema extends
+    TablesRelationalConfig = ExtractTablesWithRelations<TFullSchema>,
+>(
+  args: DrizzleSinkOptions<TTableConfig, TQueryResult, TFullSchema, TSchema>,
+) => {
+  return new DrizzleSink(args);
+};

--- a/packages/indexer/src/testing/indexer.ts
+++ b/packages/indexer/src/testing/indexer.ts
@@ -33,5 +33,3 @@ export const getMockIndexer = <TTxnParams>({
 export type MockRet = {
   data: string;
 };
-
-export type MockTxnParams = unknown;

--- a/packages/indexer/src/testing/indexer.ts
+++ b/packages/indexer/src/testing/indexer.ts
@@ -3,26 +3,35 @@ import {
   type MockFilter,
   MockStream,
 } from "@apibara/protocol/testing";
-import { createIndexer, defineIndexer } from "../indexer";
+import { type IndexerConfig, createIndexer, defineIndexer } from "../indexer";
 import type { IndexerPlugin } from "../plugins";
+import type { Sink } from "../sink";
 
-export const getMockIndexer = (
-  plugins: ReadonlyArray<IndexerPlugin<MockFilter, MockBlock, MockRet>> = [],
-) =>
+export const getMockIndexer = <TTxnParams>({
+  plugins,
+  sink,
+  override,
+}: {
+  plugins?: ReadonlyArray<IndexerPlugin<MockFilter, MockBlock, TTxnParams>>;
+  sink?: Sink<TTxnParams>;
+  override?: Partial<IndexerConfig<MockFilter, MockBlock, TTxnParams>>;
+} = {}) =>
   createIndexer(
     defineIndexer(MockStream)({
       streamUrl: "https://sepolia.ethereum.a5a.ch",
       finality: "accepted",
       filter: {},
-      async transform({ block: { data } }) {
-        if (!data) return [];
-
-        return [{ data }];
+      async transform({ block: { data }, context }) {
+        // TODO
       },
+      sink,
       plugins,
+      ...override,
     }),
   );
 
 export type MockRet = {
   data: string;
 };
+
+export type MockTxnParams = unknown;

--- a/packages/indexer/src/testing/setup.ts
+++ b/packages/indexer/src/testing/setup.ts
@@ -16,17 +16,17 @@ export const test = viTest.extend({
   },
 });
 
-type WithClientContext<TFilter, TBlock, TRet> = {
+type WithClientContext<TFilter, TBlock, TTxnParams> = {
   run: (
-    indexerArgs: Indexer<TFilter, TBlock, TRet>,
+    indexerArgs: Indexer<TFilter, TBlock, TTxnParams>,
   ) => Promise<VcrReplayResult>;
 };
 
-async function withClient<TFilter, TBlock, TRet>(
+async function withClient<TFilter, TBlock, TTxnParams>(
   cassetteName: string,
   range: { fromBlock: bigint; toBlock: bigint },
   callback: (
-    context: WithClientContext<TFilter, TBlock, TRet>,
+    context: WithClientContext<TFilter, TBlock, TTxnParams>,
   ) => Promise<void>,
 ) {
   const vcrConfig: VcrConfig = {
@@ -43,7 +43,7 @@ async function withClient<TFilter, TBlock, TRet>(
     },
   };
 
-  const context: WithClientContext<TFilter, TBlock, TRet> = {
+  const context: WithClientContext<TFilter, TBlock, TTxnParams> = {
     async run(indexer) {
       const client = loadCassette<TFilter, TBlock>(vcrConfig, cassetteName);
 

--- a/packages/indexer/src/testing/vcr.ts
+++ b/packages/indexer/src/testing/vcr.ts
@@ -1,13 +1,46 @@
-import { Sink, type SinkWriteArgs } from "../sink";
+import type { Cursor } from "@apibara/protocol";
+import { Sink, type SinkData } from "../sink";
 import type { VcrReplayResult } from "../vcr";
+
+type TxnContext = {
+  buffer: SinkData[];
+  endCursor?: Cursor;
+};
+
+type TxnParams = {
+  writer: (endCursor?: Cursor | undefined) => {
+    insert: (data: SinkData[]) => void;
+  };
+};
+
+const transactionHelper = (context: TxnContext) => (endCursor?: Cursor) => {
+  return {
+    insert: (data: SinkData[]) => {
+      context.buffer.push(...data);
+      context.endCursor = endCursor;
+    },
+  };
+};
 
 export class VcrSink extends Sink {
   public result: VcrReplayResult["outputs"] = [];
 
-  async write({ data, endCursor, finality }: SinkWriteArgs) {
-    await this.callHook("write", { data });
+  write({ data, endCursor }: { data: SinkData[]; endCursor?: Cursor }) {
+    if (data.length === 0) return;
+
     this.result.push({ data, endCursor });
-    await this.callHook("flush", { endCursor, finality });
+  }
+
+  async transaction(cb: (params: TxnParams) => Promise<void>) {
+    const context: TxnContext = {
+      buffer: [],
+      endCursor: undefined,
+    };
+
+    const writer = transactionHelper(context);
+
+    await cb({ writer });
+    this.write({ data: context.buffer, endCursor: context.endCursor });
   }
 }
 

--- a/packages/indexer/src/vcr/record.ts
+++ b/packages/indexer/src/vcr/record.ts
@@ -11,10 +11,10 @@ export type CassetteDataType<TFilter, TBlock> = {
   messages: StreamDataResponse<TBlock>[];
 };
 
-export async function record<TFilter, TBlock, TRet>(
+export async function record<TFilter, TBlock, TTxnParams>(
   vcrConfig: VcrConfig,
   client: Client<TFilter, TBlock>,
-  indexerArg: Indexer<TFilter, TBlock, TRet>,
+  indexerArg: Indexer<TFilter, TBlock, TTxnParams>,
   cassetteOptions: CassetteOptions,
 ) {
   const indexer = klona(indexerArg);

--- a/packages/indexer/src/vcr/replay.ts
+++ b/packages/indexer/src/vcr/replay.ts
@@ -9,16 +9,16 @@ import { vcr } from "../testing/vcr";
 import { type CassetteDataType, deserialize } from "../vcr";
 import type { VcrConfig } from "./config";
 
-export async function replay<TFilter, TBlock, TRet>(
+export async function replay<TFilter, TBlock, TTxnParams>(
   vcrConfig: VcrConfig,
-  indexer: Indexer<TFilter, TBlock, TRet>,
+  indexer: Indexer<TFilter, TBlock, TTxnParams>,
   cassetteName: string,
 ): Promise<VcrReplayResult> {
   const client = loadCassette<TFilter, TBlock>(vcrConfig, cassetteName);
 
   const sink = vcr();
 
-  await run(client, indexer, sink);
+  await run(client, indexer);
 
   return {
     outputs: sink.result,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,12 @@ importers:
       csv-stringify:
         specifier: ^6.5.0
         version: 6.5.0
+      drizzle-orm:
+        specifier: ^0.33.0
+        version: 0.33.0(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.11)(better-sqlite3@11.1.2)(postgres@3.4.4)
+      postgres:
+        specifier: ^3.4.4
+        version: 3.4.4
       viem:
         specifier: ^2.12.4
         version: 2.13.8(typescript@5.4.5)
@@ -195,6 +201,12 @@ importers:
       csv-stringify:
         specifier: ^6.5.0
         version: 6.5.0
+      drizzle-orm:
+        specifier: ^0.33.0
+        version: 0.33.0(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.11)(better-sqlite3@11.1.2)(postgres@3.4.4)
+      postgres:
+        specifier: ^3.4.4
+        version: 3.4.4
       sqlite:
         specifier: ^5.1.1
         version: 5.1.1
@@ -422,6 +434,9 @@ importers:
       csv-stringify:
         specifier: ^6.5.0
         version: 6.5.0
+      drizzle-orm:
+        specifier: ^0.33.0
+        version: 0.33.0(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.11)(better-sqlite3@11.1.2)(postgres@3.4.4)
       unbuild:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.4.5)
@@ -1937,7 +1952,6 @@ packages:
   /@opentelemetry/api@1.9.0:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
-    dev: false
 
   /@opentelemetry/context-async-hooks@1.25.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-sBW313mnMyFg0cp/40BRzrZBWG+581s2j5gIsa5fgGadswyILk4mNFATsqrCOpAx945RDuZ2B7ThQLgor9OpfA==}
@@ -2564,7 +2578,6 @@ packages:
     resolution: {integrity: sha512-i8KcD3PgGtGBLl3+mMYA8PdKkButvPyARxA7IQAd6qeslht13qxb1zzO8dRCtE7U3IoJS782zDBAeoKiM695kg==}
     dependencies:
       '@types/node': 20.14.0
-    dev: true
 
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
@@ -3448,6 +3461,100 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
     dev: true
+
+  /drizzle-orm@0.33.0(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.11)(better-sqlite3@11.1.2)(postgres@3.4.4):
+    resolution: {integrity: sha512-SHy72R2Rdkz0LEq0PSG/IdvnT3nGiWuRk+2tXZQ90GVq/XQhpCzu/EFT3V2rox+w8MlkBQxifF8pCStNYnERfA==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=3'
+      '@electric-sql/pglite': '>=0.1.1'
+      '@libsql/client': '*'
+      '@neondatabase/serverless': '>=0.1'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/react': '>=18'
+      '@types/sql.js': '*'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=13.2.0'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      react: '>=18'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/react':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/better-sqlite3': 7.6.11
+      better-sqlite3: 11.1.2
+      postgres: 3.4.4
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -5305,6 +5412,10 @@ packages:
       picocolors: 1.0.1
       source-map-js: 1.2.0
     dev: true
+
+  /postgres@3.4.4:
+    resolution: {integrity: sha512-IbyN+9KslkqcXa8AO9fxpk97PA4pzewvpi2B3Dwy9u4zpV32QicaEdgmF3eSQUzdRk7ttDHQejNgAEr4XoeH4A==}
+    engines: {node: '>=12'}
 
   /prebuild-install@7.1.2:
     resolution: {integrity: sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==}


### PR DESCRIPTION
- upgrade sink interface
- add sink and its transaction to indexer context
- add drizzle sink for postgres
- update csv, sqlite sink
- add `useSink` hook
- update indexer examples
- update persistence and kv plugin
- update vcr and tests