### PR TITLE
indexer: rename pgTable to pgIndexerTable

### DIFF
--- a/change/@apibara-indexer-43e28d2b-5062-4907-8504-f0287b439697.json
+++ b/change/@apibara-indexer-43e28d2b-5062-4907-8504-f0287b439697.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "indexer: rename pgTable to pgIndexerTable",
+  "packageName": "@apibara/indexer",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/examples/starknet-indexer/src/indexer.ts
+++ b/examples/starknet-indexer/src/indexer.ts
@@ -1,7 +1,7 @@
 import { defineIndexer, useSink } from "@apibara/indexer";
 import {
   drizzle as drizzleSink,
-  pgTable,
+  pgIndexerTable,
 } from "@apibara/indexer/sinks/drizzle";
 import { StarknetStream } from "@apibara/starknet";
 import consola from "consola";
@@ -9,7 +9,7 @@ import { bigint } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
-const headers = pgTable("headers", {
+const headers = pgIndexerTable("headers", {
   number: bigint("number", { mode: "bigint" }),
 });
 

--- a/packages/indexer/src/sinks/drizzle/drizzle.test.ts
+++ b/packages/indexer/src/sinks/drizzle/drizzle.test.ts
@@ -15,9 +15,9 @@ import { generateMockMessages } from "../../testing";
 import { getMockIndexer } from "../../testing/indexer";
 import type { Int8Range } from "./Int8Range";
 import { drizzle as drizzleSink } from "./drizzle";
-import { getDrizzleCursor, pgTable } from "./utils";
+import { getDrizzleCursor, pgIndexerTable } from "./utils";
 
-const testTable = pgTable("test_table", {
+const testTable = pgIndexerTable("test_table", {
   id: serial("id").primaryKey(),
   data: text("data"),
 });

--- a/packages/indexer/src/sinks/drizzle/utils.ts
+++ b/packages/indexer/src/sinks/drizzle/utils.ts
@@ -29,7 +29,7 @@ export type CursorColumnBuilder = NotNull<
 >;
 
 // Redefining the type of `pgTable` to include the `_cursor` column.
-export type PgTableWithCursorFn<
+export type PgIndexerTableWithCursorFn<
   TSchema extends string | undefined = undefined,
 > = <
   TTableName extends string,
@@ -66,7 +66,11 @@ export type PgInsertValue<TTable extends PgTable> = Omit<
   "_cursor"
 >;
 
-export const pgTable: PgTableWithCursorFn = (name, columns, extraConfig?) => {
+export const pgIndexerTable: PgIndexerTableWithCursorFn = (
+  name,
+  columns,
+  extraConfig?,
+) => {
   return drizzlePgTable(
     name,
     {


### PR DESCRIPTION
This enables developers to use plain pgTable and pgIndexerTable in the same schema file.
