### PR TITLE
indexer: add hooks for each message type

### DIFF
--- a/change/@apibara-indexer-67090bf0-932b-45a7-b9a7-91d1ef752364.json
+++ b/change/@apibara-indexer-67090bf0-932b-45a7-b9a7-91d1ef752364.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "indexer: add hooks for each message type",
+  "packageName": "@apibara/indexer",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/examples/cli/indexers/evm.indexer.ts
+++ b/examples/cli/indexers/evm.indexer.ts
@@ -1,0 +1,18 @@
+import { EvmStream } from "@apibara/evm";
+import { defineIndexer } from "@apibara/indexer";
+
+export default defineIndexer(EvmStream)({
+  streamUrl: "http://localhost:7007",
+  finality: "accepted",
+  filter: {
+    header: "always",
+  },
+  async transform({ cursor, endCursor }) {
+    console.log({ cursor, endCursor });
+  },
+  hooks: {
+    "message:invalidate"({ message }) {
+      console.warn(message);
+    },
+  },
+});

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -19,6 +19,7 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
+    "@apibara/evm": "workspace:*",
     "@apibara/indexer": "workspace:*",
     "@apibara/protocol": "workspace:*",
     "@apibara/starknet": "workspace:*",

--- a/packages/indexer/src/sink.ts
+++ b/packages/indexer/src/sink.ts
@@ -16,6 +16,7 @@ export abstract class Sink<TTxnParams = unknown> {
   ): Promise<void>;
 
   abstract invalidate(cursor?: Cursor): Promise<void>;
+  abstract finalize(cursor?: Cursor): Promise<void>;
 }
 
 export class DefaultSink extends Sink<unknown> {
@@ -28,6 +29,10 @@ export class DefaultSink extends Sink<unknown> {
 
   async invalidate(cursor?: Cursor) {
     consola.info(`Invalidating cursor ${cursor?.orderKey}`);
+  }
+
+  async finalize(cursor?: Cursor) {
+    consola.info(`Finalizing cursor ${cursor?.orderKey}`);
   }
 }
 

--- a/packages/indexer/src/sinks/csv.ts
+++ b/packages/indexer/src/sinks/csv.ts
@@ -104,6 +104,11 @@ export class CsvSink extends Sink {
     throw new Error("Not implemented");
   }
 
+  async finalize(cursor?: Cursor) {
+    // TODO: Implement
+    throw new Error("Not implemented");
+  }
+
   private async insertToCSV(data: SinkData[]) {
     if (data.length === 0) return;
 

--- a/packages/indexer/src/sinks/drizzle/drizzle.ts
+++ b/packages/indexer/src/sinks/drizzle/drizzle.ts
@@ -101,6 +101,11 @@ export class DrizzleSink<
       }
     });
   }
+
+  async finalize(cursor?: Cursor) {
+    // TODO: Implement
+    throw new Error("Not implemented");
+  }
 }
 
 export const drizzle = <

--- a/packages/indexer/src/sinks/sqlite.ts
+++ b/packages/indexer/src/sinks/sqlite.ts
@@ -104,6 +104,11 @@ export class SqliteSink extends Sink {
     throw new Error("Not implemented");
   }
 
+  async finalize(cursor?: Cursor) {
+    // TODO: Implement
+    throw new Error("Not implemented");
+  }
+
   private async insertJsonArray(data: SinkData[]) {
     if (data.length === 0) return;
 

--- a/packages/indexer/src/testing/vcr.ts
+++ b/packages/indexer/src/testing/vcr.ts
@@ -47,6 +47,11 @@ export class VcrSink extends Sink {
     // TODO: Implement
     throw new Error("Not implemented");
   }
+
+  async finalize(cursor?: Cursor) {
+    // TODO: Implement
+    throw new Error("Not implemented");
+  }
 }
 
 export function vcr() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
 
   examples/cli:
     dependencies:
+      '@apibara/evm':
+        specifier: workspace:*
+        version: link:../../packages/evm
       '@apibara/indexer':
         specifier: workspace:*
         version: link:../../packages/indexer


### PR DESCRIPTION
Now the indexer can consume a stream that handles reorgs.