### PR TITLE
example: add factory mode and pglite persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 bun.lockb
 .vscode
 .apibara
+.persistence

--- a/change/apibara-5146fc27-9558-48ae-819b-7000820431b8.json
+++ b/change/apibara-5146fc27-9558-48ae-819b-7000820431b8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "cli: add @electric-sql/pglite as external dependency",
+  "packageName": "apibara",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/examples/cli/indexers/3-starknet-factory.indexer.ts
+++ b/examples/cli/indexers/3-starknet-factory.indexer.ts
@@ -1,0 +1,52 @@
+import { defineIndexer } from "@apibara/indexer";
+import { useLogger } from "@apibara/indexer/plugins/logger";
+import { StarknetStream } from "@apibara/starknet";
+import type { ApibaraRuntimeConfig } from "apibara/types";
+import { hash } from "starknet";
+
+const PAIR_CREATED = hash.getSelectorFromName("PairCreated") as `0x${string}`;
+const SWAP = hash.getSelectorFromName("Swap") as `0x${string}`;
+
+export default function (runtimeConfig: ApibaraRuntimeConfig) {
+  return defineIndexer(StarknetStream)({
+    streamUrl: "https://starknet.preview.apibara.org",
+    finality: "accepted",
+    startingCursor: {
+      orderKey: 800_000n,
+    },
+    filter: {
+      header: "always",
+      events: [
+        {
+          address:
+            "0x00dad44c139a476c7a17fc8141e6db680e9abc9f56fe249a105094c44382c2fd",
+          keys: [PAIR_CREATED],
+        },
+      ],
+    },
+    async factory({ block: { events } }) {
+      const logger = useLogger();
+
+      const poolEvents = (events ?? []).flatMap((event) => {
+        const pairAddress = event.data?.[2];
+
+        logger.log(`Factory: PairAddress - ${pairAddress}`);
+        return {
+          address: pairAddress,
+          keys: [SWAP],
+          includeReceipt: false,
+        };
+      });
+      return {
+        filter: {
+          header: "always",
+          events: poolEvents,
+        },
+      };
+    },
+    async transform({ block, endCursor }) {
+      const logger = useLogger();
+      logger.log("Transforming ", endCursor?.orderKey);
+    },
+  });
+}

--- a/examples/cli/indexers/3-starknet-factory.indexer.ts
+++ b/examples/cli/indexers/3-starknet-factory.indexer.ts
@@ -6,6 +6,8 @@ import { hash } from "starknet";
 
 const PAIR_CREATED = hash.getSelectorFromName("PairCreated") as `0x${string}`;
 const SWAP = hash.getSelectorFromName("Swap") as `0x${string}`;
+const shortAddress = (addr?: string) =>
+  addr ? `${addr.slice(0, 6)}...${addr.slice(-4)}` : "";
 
 export default function (runtimeConfig: ApibaraRuntimeConfig) {
   return defineIndexer(StarknetStream)({
@@ -30,23 +32,34 @@ export default function (runtimeConfig: ApibaraRuntimeConfig) {
       const poolEvents = (events ?? []).flatMap((event) => {
         const pairAddress = event.data?.[2];
 
-        logger.log(`Factory: PairAddress - ${pairAddress}`);
+        logger.log(
+          "Factory: PairAddress    : ",
+          `\x1b[35m${pairAddress}\x1b[0m`,
+        );
         return {
           address: pairAddress,
           keys: [SWAP],
-          includeReceipt: false,
         };
       });
       return {
         filter: {
-          header: "always",
           events: poolEvents,
         },
       };
     },
     async transform({ block, endCursor }) {
       const logger = useLogger();
-      logger.log("Transforming ", endCursor?.orderKey);
+      const { events } = block;
+
+      logger.log("Transforming...         : ", endCursor?.orderKey);
+      for (const event of events) {
+        logger.log(
+          "Event Address           : ",
+          shortAddress(event.address),
+          "| Txn hash :",
+          shortAddress(event.transactionHash),
+        );
+      }
     },
   });
 }

--- a/packages/cli/src/rollup/config.ts
+++ b/packages/cli/src/rollup/config.ts
@@ -12,7 +12,7 @@ import { appConfig } from "./plugins/config";
 import { esmShim } from "./plugins/esm-shim";
 import { indexers } from "./plugins/indexers";
 
-const runtimeDependencies = ["better-sqlite3"];
+const runtimeDependencies = ["better-sqlite3", "@electric-sql/pglite"];
 
 export function getRollupConfig(apibara: Apibara): RollupConfig {
   const extensions: string[] = [


### PR DESCRIPTION
- add `@electric-sql/pglite` as external dependency in rollup for cli
- add pglite persistence in example
- add factory mode example