### PR TITLE
Update protocol with index in transaction fields

### DIFF
--- a/change/@apibara-evm-f1bb6555-a641-4402-82e4-692be980ad21.json
+++ b/change/@apibara-evm-f1bb6555-a641-4402-82e4-692be980ad21.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "starknet: add event and message index in transaction",
+  "packageName": "@apibara/evm",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-starknet-5f888e7b-83d2-4a42-b2b5-d60e55fc7d2d.json
+++ b/change/@apibara-starknet-5f888e7b-83d2-4a42-b2b5-d60e55fc7d2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "evm: add log index in transaction field",
+  "packageName": "@apibara/starknet",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/packages/evm/proto/data.proto
+++ b/packages/evm/proto/data.proto
@@ -175,6 +175,8 @@ message Log {
   B256 transaction_hash = 7;
   // The transaction status.
   TransactionStatus transaction_status = 8;
+  // Index of the log in the transaction.
+  uint32 log_index_in_transaction = 9;
 }
 
 message Signature {

--- a/packages/evm/src/block.ts
+++ b/packages/evm/src/block.ts
@@ -135,6 +135,7 @@ export const Log = Schema.Struct({
   topics: Schema.Array(B256),
   data: BytesFromUint8Array,
   logIndex: Schema.Number,
+  logIndexInTransaction: Schema.Number,
   transactionIndex: Schema.Number,
   transactionHash: Schema.optional(B256),
   transactionStatus: Schema.optional(TransactionStatus),

--- a/packages/evm/src/proto/data.ts
+++ b/packages/evm/src/proto/data.ts
@@ -351,7 +351,11 @@ export interface Log {
     | B256
     | undefined;
   /** The transaction status. */
-  readonly transactionStatus?: TransactionStatus | undefined;
+  readonly transactionStatus?:
+    | TransactionStatus
+    | undefined;
+  /** Index of the log in the transaction. */
+  readonly logIndexInTransaction?: number | undefined;
 }
 
 export interface Signature {
@@ -1830,6 +1834,7 @@ function createBaseLog(): Log {
     transactionIndex: 0,
     transactionHash: undefined,
     transactionStatus: 0,
+    logIndexInTransaction: 0,
   };
 }
 
@@ -1864,6 +1869,9 @@ export const Log = {
     }
     if (message.transactionStatus !== undefined && message.transactionStatus !== 0) {
       writer.uint32(64).int32(message.transactionStatus);
+    }
+    if (message.logIndexInTransaction !== undefined && message.logIndexInTransaction !== 0) {
+      writer.uint32(72).uint32(message.logIndexInTransaction);
     }
     return writer;
   },
@@ -1941,6 +1949,13 @@ export const Log = {
 
           message.transactionStatus = reader.int32() as any;
           continue;
+        case 9:
+          if (tag !== 72) {
+            break;
+          }
+
+          message.logIndexInTransaction = reader.uint32();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1962,6 +1977,7 @@ export const Log = {
       transactionIndex: isSet(object.transactionIndex) ? globalThis.Number(object.transactionIndex) : 0,
       transactionHash: isSet(object.transactionHash) ? B256.fromJSON(object.transactionHash) : undefined,
       transactionStatus: isSet(object.transactionStatus) ? transactionStatusFromJSON(object.transactionStatus) : 0,
+      logIndexInTransaction: isSet(object.logIndexInTransaction) ? globalThis.Number(object.logIndexInTransaction) : 0,
     };
   },
 
@@ -1991,6 +2007,9 @@ export const Log = {
     if (message.transactionStatus !== undefined && message.transactionStatus !== 0) {
       obj.transactionStatus = transactionStatusToJSON(message.transactionStatus);
     }
+    if (message.logIndexInTransaction !== undefined && message.logIndexInTransaction !== 0) {
+      obj.logIndexInTransaction = Math.round(message.logIndexInTransaction);
+    }
     return obj;
   },
 
@@ -2011,6 +2030,7 @@ export const Log = {
       ? B256.fromPartial(object.transactionHash)
       : undefined;
     message.transactionStatus = object.transactionStatus ?? 0;
+    message.logIndexInTransaction = object.logIndexInTransaction ?? 0;
     return message;
   },
 };

--- a/packages/starknet/proto/data.proto
+++ b/packages/starknet/proto/data.proto
@@ -257,6 +257,8 @@ message Event {
   FieldElement transaction_hash = 7;
   // Transaction status.
   TransactionStatus transaction_status = 8;
+  // Event index in the transaction.
+  uint32 event_index_in_transaction = 9;
 }
 
 message MessageToL1 {
@@ -275,6 +277,8 @@ message MessageToL1 {
   FieldElement transaction_hash = 7;
   // Transaction status.
   TransactionStatus transaction_status = 8;
+  // Message index in the transaction.
+  uint32 message_index_in_transaction = 9;
 }
 
 enum L1DataAvailabilityMode {

--- a/packages/starknet/src/block.ts
+++ b/packages/starknet/src/block.ts
@@ -442,6 +442,7 @@ export type TransactionReceipt = typeof TransactionReceipt.Type;
  * @prop transactionIndex The transaction index in the block.
  * @prop transactionHash The transaction hash.
  * @prop transactionStatus The transaction status.
+ * @prop eventIndexInTransaction The event index in the transaction.
  */
 export const Event = Schema.Struct({
   filterIds: Schema.optional(Schema.Array(Schema.Number)),
@@ -452,6 +453,7 @@ export const Event = Schema.Struct({
   transactionIndex: Schema.optional(Schema.Number),
   transactionHash: Schema.optional(FieldElement),
   transactionStatus: Schema.optional(TransactionStatus),
+  eventIndexInTransaction: Schema.optional(Schema.Number),
 });
 
 export type Event = typeof Event.Type;
@@ -465,6 +467,7 @@ export type Event = typeof Event.Type;
  * @prop transactionIndex The transaction index in the block.
  * @prop transactionHash The transaction hash.
  * @prop transactionStatus The transaction status.
+ * @prop messageIndexInTransaction The message index in the transaction.
  */
 export const MessageToL1 = Schema.Struct({
   filterIds: Schema.optional(Schema.Array(Schema.Number)),
@@ -475,6 +478,7 @@ export const MessageToL1 = Schema.Struct({
   transactionIndex: Schema.optional(Schema.Number),
   transactionHash: Schema.optional(FieldElement),
   transactionStatus: Schema.optional(TransactionStatus),
+  messageIndexInTransaction: Schema.optional(Schema.Number),
 });
 
 export type MessageToL1 = typeof MessageToL1.Type;

--- a/packages/starknet/src/proto/data.ts
+++ b/packages/starknet/src/proto/data.ts
@@ -518,7 +518,11 @@ export interface Event {
     | FieldElement
     | undefined;
   /** Transaction status. */
-  readonly transactionStatus?: TransactionStatus | undefined;
+  readonly transactionStatus?:
+    | TransactionStatus
+    | undefined;
+  /** Event index in the transaction. */
+  readonly eventIndexInTransaction?: number | undefined;
 }
 
 export interface MessageToL1 {
@@ -550,7 +554,11 @@ export interface MessageToL1 {
     | FieldElement
     | undefined;
   /** Transaction status. */
-  readonly transactionStatus?: TransactionStatus | undefined;
+  readonly transactionStatus?:
+    | TransactionStatus
+    | undefined;
+  /** Message index in the transaction. */
+  readonly messageIndexInTransaction?: number | undefined;
 }
 
 /** Price of a unit of a resource. */
@@ -4141,6 +4149,7 @@ function createBaseEvent(): Event {
     transactionIndex: 0,
     transactionHash: undefined,
     transactionStatus: 0,
+    eventIndexInTransaction: 0,
   };
 }
 
@@ -4177,6 +4186,9 @@ export const Event = {
     }
     if (message.transactionStatus !== undefined && message.transactionStatus !== 0) {
       writer.uint32(64).int32(message.transactionStatus);
+    }
+    if (message.eventIndexInTransaction !== undefined && message.eventIndexInTransaction !== 0) {
+      writer.uint32(72).uint32(message.eventIndexInTransaction);
     }
     return writer;
   },
@@ -4254,6 +4266,13 @@ export const Event = {
 
           message.transactionStatus = reader.int32() as any;
           continue;
+        case 9:
+          if (tag !== 72) {
+            break;
+          }
+
+          message.eventIndexInTransaction = reader.uint32();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -4275,6 +4294,9 @@ export const Event = {
       transactionIndex: isSet(object.transactionIndex) ? globalThis.Number(object.transactionIndex) : 0,
       transactionHash: isSet(object.transactionHash) ? FieldElement.fromJSON(object.transactionHash) : undefined,
       transactionStatus: isSet(object.transactionStatus) ? transactionStatusFromJSON(object.transactionStatus) : 0,
+      eventIndexInTransaction: isSet(object.eventIndexInTransaction)
+        ? globalThis.Number(object.eventIndexInTransaction)
+        : 0,
     };
   },
 
@@ -4304,6 +4326,9 @@ export const Event = {
     if (message.transactionStatus !== undefined && message.transactionStatus !== 0) {
       obj.transactionStatus = transactionStatusToJSON(message.transactionStatus);
     }
+    if (message.eventIndexInTransaction !== undefined && message.eventIndexInTransaction !== 0) {
+      obj.eventIndexInTransaction = Math.round(message.eventIndexInTransaction);
+    }
     return obj;
   },
 
@@ -4324,6 +4349,7 @@ export const Event = {
       ? FieldElement.fromPartial(object.transactionHash)
       : undefined;
     message.transactionStatus = object.transactionStatus ?? 0;
+    message.eventIndexInTransaction = object.eventIndexInTransaction ?? 0;
     return message;
   },
 };
@@ -4338,6 +4364,7 @@ function createBaseMessageToL1(): MessageToL1 {
     transactionIndex: 0,
     transactionHash: undefined,
     transactionStatus: 0,
+    messageIndexInTransaction: 0,
   };
 }
 
@@ -4372,6 +4399,9 @@ export const MessageToL1 = {
     }
     if (message.transactionStatus !== undefined && message.transactionStatus !== 0) {
       writer.uint32(64).int32(message.transactionStatus);
+    }
+    if (message.messageIndexInTransaction !== undefined && message.messageIndexInTransaction !== 0) {
+      writer.uint32(72).uint32(message.messageIndexInTransaction);
     }
     return writer;
   },
@@ -4449,6 +4479,13 @@ export const MessageToL1 = {
 
           message.transactionStatus = reader.int32() as any;
           continue;
+        case 9:
+          if (tag !== 72) {
+            break;
+          }
+
+          message.messageIndexInTransaction = reader.uint32();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -4472,6 +4509,9 @@ export const MessageToL1 = {
       transactionIndex: isSet(object.transactionIndex) ? globalThis.Number(object.transactionIndex) : 0,
       transactionHash: isSet(object.transactionHash) ? FieldElement.fromJSON(object.transactionHash) : undefined,
       transactionStatus: isSet(object.transactionStatus) ? transactionStatusFromJSON(object.transactionStatus) : 0,
+      messageIndexInTransaction: isSet(object.messageIndexInTransaction)
+        ? globalThis.Number(object.messageIndexInTransaction)
+        : 0,
     };
   },
 
@@ -4501,6 +4541,9 @@ export const MessageToL1 = {
     if (message.transactionStatus !== undefined && message.transactionStatus !== 0) {
       obj.transactionStatus = transactionStatusToJSON(message.transactionStatus);
     }
+    if (message.messageIndexInTransaction !== undefined && message.messageIndexInTransaction !== 0) {
+      obj.messageIndexInTransaction = Math.round(message.messageIndexInTransaction);
+    }
     return obj;
   },
 
@@ -4523,6 +4566,7 @@ export const MessageToL1 = {
       ? FieldElement.fromPartial(object.transactionHash)
       : undefined;
     message.transactionStatus = object.transactionStatus ?? 0;
+    message.messageIndexInTransaction = object.messageIndexInTransaction ?? 0;
     return message;
   },
 };


### PR DESCRIPTION
This PR adds the `{event,message,log}IndexInTransaction` fields to track the index inside a transaction.
