### PR TITLE
plugin-drizzle: fix concurrency issue during initialization

### DIFF
--- a/change/@apibara-indexer-10c147e4-d02c-49b5-825f-40ebd5ba16ec.json
+++ b/change/@apibara-indexer-10c147e4-d02c-49b5-825f-40ebd5ba16ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "indexer: add internalContext plugin and update mock methods",
+  "packageName": "@apibara/indexer",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-plugin-drizzle-1364b96a-b614-40a0-990f-5844e1845e86.json
+++ b/change/@apibara-plugin-drizzle-1364b96a-b614-40a0-990f-5844e1845e86.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugin-drizzle: resolve concurrency issues with retries",
+  "packageName": "@apibara/plugin-drizzle",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-plugin-mongo-b3bdf6ab-42ab-4d6a-8acf-a4f7cb940a1a.json
+++ b/change/@apibara-plugin-mongo-b3bdf6ab-42ab-4d6a-8acf-a4f7cb940a1a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugins: add indexerId and update tests",
+  "packageName": "@apibara/plugin-mongo",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-plugin-sqlite-b026ca88-9927-4840-a95e-90776a18ccd0.json
+++ b/change/@apibara-plugin-sqlite-b026ca88-9927-4840-a95e-90776a18ccd0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugins: add indexerId and update tests",
+  "packageName": "@apibara/plugin-sqlite",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/apibara-9a822397-0994-4786-a9d7-0ad9986112d7.json
+++ b/change/apibara-9a822397-0994-4786-a9d7-0ad9986112d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "cli: add internalContext plugin for runtime context",
+  "packageName": "apibara",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/runtime/internal/app.ts
+++ b/packages/cli/src/runtime/internal/app.ts
@@ -1,13 +1,15 @@
 import { createIndexer as _createIndexer } from "@apibara/indexer";
 import {
+  type InternalContext,
+  internalContext,
+} from "@apibara/indexer/internal/plugins";
+import {
   type ConsolaReporter,
   inMemoryPersistence,
   logger,
 } from "@apibara/indexer/plugins";
-
 import { config } from "#apibara-internal-virtual/config";
 import { indexers } from "#apibara-internal-virtual/indexers";
-
 import { createLogger } from "./logger";
 
 export const availableIndexers = indexers.map((i) => i.name);
@@ -63,6 +65,10 @@ export function createIndexer(indexerName: string, preset?: string) {
   // persistence plugin.
   // Put the logger last since we want to override any user-defined logger.
   definition.plugins = [
+    internalContext({
+      indexerName,
+      availableIndexers,
+    } as InternalContext),
     inMemoryPersistence(),
     ...(definition.plugins ?? []),
     logger({ logger: reporter }),

--- a/packages/indexer/build.config.ts
+++ b/packages/indexer/build.config.ts
@@ -7,6 +7,8 @@ export default defineBuildConfig({
     "./src/vcr/index.ts",
     "./src/plugins/index.ts",
     "./src/internal/testing.ts",
+    "./src/internal/plugins.ts",
+    "./src/internal/index.ts",
   ],
   clean: true,
   outDir: "./dist",

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -35,10 +35,22 @@
       "default": "./dist/plugins/index.mjs"
     },
     "./internal": {
+      "types": "./dist/internal/index.d.ts",
+      "import": "./dist/internal/index.mjs",
+      "require": "./dist/internal/index.cjs",
+      "default": "./dist/internal/index.mjs"
+    },
+    "./internal/testing": {
       "types": "./dist/internal/testing.d.ts",
       "import": "./dist/internal/testing.mjs",
       "require": "./dist/internal/testing.cjs",
       "default": "./dist/internal/testing.mjs"
+    },
+    "./internal/plugins": {
+      "types": "./dist/internal/plugins.d.ts",
+      "import": "./dist/internal/plugins.mjs",
+      "require": "./dist/internal/plugins.cjs",
+      "default": "./dist/internal/plugins.mjs"
     }
   },
   "scripts": {

--- a/packages/indexer/src/indexer.test.ts
+++ b/packages/indexer/src/indexer.test.ts
@@ -248,8 +248,8 @@ describe("Run Test", () => {
     const metadata: Record<string, unknown> = {};
 
     const indexer = getMockIndexer({
-      plugins: [mockSink({ output, metadata })],
       override: {
+        plugins: [mockSink({ output, metadata })],
         startingCursor: { orderKey: 100n },
         factory: async ({ block }) => {
           if (block.data === "B") {
@@ -400,8 +400,8 @@ describe("Run Test", () => {
     const metadata: Record<string, unknown> = {};
 
     const indexer = getMockIndexer({
-      plugins: [mockSink({ output, metadata })],
       override: {
+        plugins: [mockSink({ output, metadata })],
         startingCursor: { orderKey: 100n },
         factory: async ({ block }) => {
           if (block.data === "B") {

--- a/packages/indexer/src/internal/index.ts
+++ b/packages/indexer/src/internal/index.ts
@@ -1,0 +1,6 @@
+export function generateIndexerId(fileBasedName: string, identifier?: string) {
+  return `indexer_${fileBasedName}_${identifier || "default"}`.replace(
+    /[^a-zA-Z0-9_]/g,
+    "_",
+  );
+}

--- a/packages/indexer/src/internal/plugins.ts
+++ b/packages/indexer/src/internal/plugins.ts
@@ -1,0 +1,1 @@
+export * from "../plugins/context";

--- a/packages/indexer/src/plugins/context.ts
+++ b/packages/indexer/src/plugins/context.ts
@@ -1,0 +1,37 @@
+import { useIndexerContext } from "../context";
+import { defineIndexerPlugin } from "./config";
+
+export const INTERNAL_CONTEXT_PROPERTY = "_internal";
+
+export function internalContext<TFilter, TBlock, TTxnParams>(
+  values: Record<string, unknown>,
+) {
+  return defineIndexerPlugin<TFilter, TBlock>((indexer) => {
+    indexer.hooks.hook("run:before", () => {
+      try {
+        const ctx = useIndexerContext();
+        ctx[INTERNAL_CONTEXT_PROPERTY] = {
+          ...(ctx[INTERNAL_CONTEXT_PROPERTY] || {}),
+          ...values,
+        };
+      } catch (error) {
+        throw new Error("Failed to set internal context", {
+          cause: error,
+        });
+      }
+    });
+  });
+}
+
+export type InternalContext = {
+  indexerName: string;
+  availableIndexers: string[];
+};
+
+export function useInternalContext(): InternalContext {
+  const ctx = useIndexerContext();
+  if (!ctx[INTERNAL_CONTEXT_PROPERTY]) {
+    throw new Error("Internal context is not available");
+  }
+  return ctx[INTERNAL_CONTEXT_PROPERTY];
+}

--- a/packages/plugin-drizzle/src/storage.ts
+++ b/packages/plugin-drizzle/src/storage.ts
@@ -25,6 +25,7 @@ export const reorgRollbackTable = pgTable("__reorg_rollback", {
   cursor: integer("cursor").notNull(),
   row_id: text("row_id"),
   row_value: jsonb("row_value"),
+  indexer_id: text("indexer_id").notNull(),
 });
 
 export type ReorgRollbackRow = typeof reorgRollbackTable.$inferSelect;
@@ -34,7 +35,7 @@ export async function initializeReorgRollbackTable<
   TFullSchema extends Record<string, unknown> = Record<string, never>,
   TSchema extends
     TablesRelationalConfig = ExtractTablesWithRelations<TFullSchema>,
->(tx: PgTransaction<TQueryResult, TFullSchema, TSchema>) {
+>(tx: PgTransaction<TQueryResult, TFullSchema, TSchema>, indexerId: string) {
   try {
     // Create the audit log table
     await tx.execute(
@@ -45,41 +46,64 @@ export async function initializeReorgRollbackTable<
           table_name TEXT NOT NULL,
           cursor INTEGER NOT NULL,
           row_id TEXT,
-          row_value JSONB
+          row_value JSONB,
+          indexer_id TEXT NOT NULL
         );
       `),
     );
 
-    // Create the trigger function
     await tx.execute(
       sql.raw(`
-        CREATE OR REPLACE FUNCTION reorg_checkpoint()
-        RETURNS TRIGGER AS $$
-        DECLARE
-          id_col TEXT := TG_ARGV[0]::TEXT;
-          order_key INTEGER := TG_ARGV[1]::INTEGER;
-          new_id_value TEXT := row_to_json(NEW.*)->>id_col;
-          old_id_value TEXT := row_to_json(OLD.*)->>id_col;
-        BEGIN
-          IF (TG_OP = 'DELETE') THEN
-            INSERT INTO __reorg_rollback(op, table_name, cursor, row_id, row_value)
-              SELECT 'D', TG_TABLE_NAME, order_key, old_id_value, row_to_json(OLD.*);
-          ELSIF (TG_OP = 'UPDATE') THEN
-            INSERT INTO __reorg_rollback(op, table_name, cursor, row_id, row_value)
-              SELECT 'U', TG_TABLE_NAME, order_key, new_id_value, row_to_json(OLD.*);
-          ELSIF (TG_OP = 'INSERT') THEN
-            INSERT INTO __reorg_rollback(op, table_name, cursor, row_id, row_value)
-              SELECT 'I', TG_TABLE_NAME, order_key, new_id_value, null;
-          END IF;
-          RETURN NULL;
-        END;
-        $$ LANGUAGE plpgsql;
+        CREATE INDEX IF NOT EXISTS idx_reorg_rollback_indexer_id ON __reorg_rollback(indexer_id);
+      `),
+    );
+
+    await tx.execute(
+      sql.raw(`
+        CREATE INDEX IF NOT EXISTS idx_reorg_rollback_cursor ON __reorg_rollback(cursor);
       `),
     );
   } catch (error) {
     throw new DrizzleStorageError("Failed to initialize reorg rollback table", {
       cause: error,
     });
+  }
+
+  try {
+    // Create the trigger function
+    await tx.execute(
+      sql.raw(`
+      CREATE OR REPLACE FUNCTION reorg_checkpoint()
+      RETURNS TRIGGER AS $$
+      DECLARE
+        id_col TEXT := TG_ARGV[0]::TEXT;
+        order_key INTEGER := TG_ARGV[1]::INTEGER;
+        indexer_id TEXT := TG_ARGV[2]::TEXT;
+        new_id_value TEXT := row_to_json(NEW.*)->>id_col;
+        old_id_value TEXT := row_to_json(OLD.*)->>id_col;
+      BEGIN
+        IF (TG_OP = 'DELETE') THEN
+          INSERT INTO __reorg_rollback(op, table_name, cursor, row_id, row_value, indexer_id)
+            SELECT 'D', TG_TABLE_NAME, order_key, old_id_value, row_to_json(OLD.*), indexer_id;
+        ELSIF (TG_OP = 'UPDATE') THEN
+          INSERT INTO __reorg_rollback(op, table_name, cursor, row_id, row_value, indexer_id)
+            SELECT 'U', TG_TABLE_NAME, order_key, new_id_value, row_to_json(OLD.*), indexer_id;
+        ELSIF (TG_OP = 'INSERT') THEN
+          INSERT INTO __reorg_rollback(op, table_name, cursor, row_id, row_value, indexer_id)
+            SELECT 'I', TG_TABLE_NAME, order_key, new_id_value, null, indexer_id;
+        END IF;
+        RETURN NULL;
+      END;
+      $$ LANGUAGE plpgsql;
+    `),
+    );
+  } catch (error) {
+    throw new DrizzleStorageError(
+      "Failed to create reorg checkpoint function",
+      {
+        cause: error,
+      },
+    );
   }
 }
 
@@ -93,18 +117,21 @@ export async function registerTriggers<
   tables: string[],
   endCursor: Cursor,
   idColumn: string,
+  indexerId: string,
 ) {
   try {
     for (const table of tables) {
       await tx.execute(
-        sql.raw(`DROP TRIGGER IF EXISTS ${table}_reorg ON ${table};`),
+        sql.raw(
+          `DROP TRIGGER IF EXISTS ${table}_reorg_${indexerId} ON ${table};`,
+        ),
       );
       await tx.execute(
         sql.raw(`
-          CREATE CONSTRAINT TRIGGER ${table}_reorg
+          CREATE CONSTRAINT TRIGGER ${table}_reorg_${indexerId}
           AFTER INSERT OR UPDATE OR DELETE ON ${table}
           DEFERRABLE INITIALLY DEFERRED
-          FOR EACH ROW EXECUTE FUNCTION reorg_checkpoint('${idColumn}', ${`${Number(endCursor.orderKey)}`});
+          FOR EACH ROW EXECUTE FUNCTION reorg_checkpoint('${idColumn}', ${`${Number(endCursor.orderKey)}`}, '${indexerId}');
         `),
       );
     }
@@ -120,11 +147,17 @@ export async function removeTriggers<
   TFullSchema extends Record<string, unknown> = Record<string, never>,
   TSchema extends
     TablesRelationalConfig = ExtractTablesWithRelations<TFullSchema>,
->(db: PgDatabase<TQueryResult, TFullSchema, TSchema>, tables: string[]) {
+>(
+  db: PgDatabase<TQueryResult, TFullSchema, TSchema>,
+  tables: string[],
+  indexerId: string,
+) {
   try {
     for (const table of tables) {
       await db.execute(
-        sql.raw(`DROP TRIGGER IF EXISTS ${table}_reorg ON ${table};`),
+        sql.raw(
+          `DROP TRIGGER IF EXISTS ${table}_reorg_${indexerId} ON ${table};`,
+        ),
       );
     }
   } catch (error) {
@@ -143,6 +176,7 @@ export async function invalidate<
   tx: PgTransaction<TQueryResult, TFullSchema, TSchema>,
   cursor: Cursor,
   idColumn: string,
+  indexerId: string,
 ) {
   // Get and delete operations after cursor in one query, ordered by newest first
   const { rows: result } = (await tx.execute(
@@ -150,6 +184,7 @@ export async function invalidate<
       WITH deleted AS (
         DELETE FROM __reorg_rollback
         WHERE cursor > ${Number(cursor.orderKey)}
+        AND indexer_id = '${indexerId}'
         RETURNING *
       )
       SELECT * FROM deleted ORDER BY n DESC;
@@ -263,12 +298,17 @@ export async function finalize<
   TFullSchema extends Record<string, unknown> = Record<string, never>,
   TSchema extends
     TablesRelationalConfig = ExtractTablesWithRelations<TFullSchema>,
->(tx: PgTransaction<TQueryResult, TFullSchema, TSchema>, cursor: Cursor) {
+>(
+  tx: PgTransaction<TQueryResult, TFullSchema, TSchema>,
+  cursor: Cursor,
+  indexerId: string,
+) {
   try {
     await tx.execute(
       sql.raw(`
       DELETE FROM __reorg_rollback
       WHERE cursor <= ${Number(cursor.orderKey)}
+      AND indexer_id = '${indexerId}'
     `),
     );
   } catch (error) {

--- a/packages/plugin-drizzle/src/utils.ts
+++ b/packages/plugin-drizzle/src/utils.ts
@@ -44,3 +44,7 @@ export function serialize<T>(obj: T): string {
     "\t",
   );
 }
+
+export function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/plugin-drizzle/tests/storage.test.ts
+++ b/packages/plugin-drizzle/tests/storage.test.ts
@@ -2,7 +2,7 @@ import { run } from "@apibara/indexer";
 import {
   generateMockMessages,
   getMockIndexer,
-} from "@apibara/indexer/internal";
+} from "@apibara/indexer/internal/testing";
 import type { Finalize, Invalidate } from "@apibara/protocol";
 import {
   type MockBlock,
@@ -22,9 +22,7 @@ describe("Drizzle test", () => {
 
     const indexer = getMockIndexer({
       override: {
-        plugins: [
-          drizzleStorage({ db, persistState: true, indexerName: "testing" }),
-        ],
+        plugins: [drizzleStorage({ db, persistState: true })],
         async transform({ endCursor, block: { data } }) {
           const { db: tx } = useDrizzleStorage(db);
 
@@ -79,6 +77,7 @@ describe("Drizzle test", () => {
       [
         {
           "cursor": 5000000,
+          "indexer_id": "indexer_testing_default",
           "n": 1,
           "op": "I",
           "row_id": "1",
@@ -87,6 +86,7 @@ describe("Drizzle test", () => {
         },
         {
           "cursor": 5000001,
+          "indexer_id": "indexer_testing_default",
           "n": 2,
           "op": "I",
           "row_id": "2",
@@ -95,6 +95,7 @@ describe("Drizzle test", () => {
         },
         {
           "cursor": 5000002,
+          "indexer_id": "indexer_testing_default",
           "n": 3,
           "op": "I",
           "row_id": "3",
@@ -110,9 +111,7 @@ describe("Drizzle test", () => {
 
     const indexer = getMockIndexer({
       override: {
-        plugins: [
-          drizzleStorage({ db, persistState: true, indexerName: "testing" }),
-        ],
+        plugins: [drizzleStorage({ db, persistState: true })],
         async transform({ endCursor, block: { data } }) {
           const { db: tx } = useDrizzleStorage(db);
 
@@ -166,6 +165,7 @@ describe("Drizzle test", () => {
       [
         {
           "cursor": 5000000,
+          "indexer_id": "indexer_testing_default",
           "n": 1,
           "op": "I",
           "row_id": "1",
@@ -174,6 +174,7 @@ describe("Drizzle test", () => {
         },
         {
           "cursor": 5000001,
+          "indexer_id": "indexer_testing_default",
           "n": 2,
           "op": "U",
           "row_id": "1",
@@ -189,6 +190,7 @@ describe("Drizzle test", () => {
         },
         {
           "cursor": 5000002,
+          "indexer_id": "indexer_testing_default",
           "n": 3,
           "op": "U",
           "row_id": "1",
@@ -211,9 +213,7 @@ describe("Drizzle test", () => {
 
     const indexer = getMockIndexer({
       override: {
-        plugins: [
-          drizzleStorage({ db, persistState: true, indexerName: "testing" }),
-        ],
+        plugins: [drizzleStorage({ db, persistState: true })],
         async transform({ endCursor, block: { data } }) {
           const { db: tx } = useDrizzleStorage(db);
 
@@ -262,6 +262,7 @@ describe("Drizzle test", () => {
       [
         {
           "cursor": 5000000,
+          "indexer_id": "indexer_testing_default",
           "n": 1,
           "op": "I",
           "row_id": "1",
@@ -270,6 +271,7 @@ describe("Drizzle test", () => {
         },
         {
           "cursor": 5000001,
+          "indexer_id": "indexer_testing_default",
           "n": 2,
           "op": "D",
           "row_id": "1",
@@ -285,6 +287,7 @@ describe("Drizzle test", () => {
         },
         {
           "cursor": 5000002,
+          "indexer_id": "indexer_testing_default",
           "n": 3,
           "op": "I",
           "row_id": "2",
@@ -300,9 +303,7 @@ describe("Drizzle test", () => {
 
     const indexer = getMockIndexer({
       override: {
-        plugins: [
-          drizzleStorage({ db, persistState: true, indexerName: "testing" }),
-        ],
+        plugins: [drizzleStorage({ db, persistState: true })],
         async transform({ endCursor, block: { data } }) {
           const { db: tx } = useDrizzleStorage(db);
 
@@ -429,6 +430,7 @@ describe("Drizzle test", () => {
       [
         {
           "cursor": 5000000,
+          "indexer_id": "indexer_testing_default",
           "n": 1,
           "op": "I",
           "row_id": "1",
@@ -437,6 +439,7 @@ describe("Drizzle test", () => {
         },
         {
           "cursor": 5000001,
+          "indexer_id": "indexer_testing_default",
           "n": 2,
           "op": "I",
           "row_id": "2",
@@ -445,6 +448,7 @@ describe("Drizzle test", () => {
         },
         {
           "cursor": 5000002,
+          "indexer_id": "indexer_testing_default",
           "n": 3,
           "op": "I",
           "row_id": "3",
@@ -453,6 +457,7 @@ describe("Drizzle test", () => {
         },
         {
           "cursor": 5000003,
+          "indexer_id": "indexer_testing_default",
           "n": 4,
           "op": "I",
           "row_id": "4",
@@ -461,6 +466,7 @@ describe("Drizzle test", () => {
         },
         {
           "cursor": 5000004,
+          "indexer_id": "indexer_testing_default",
           "n": 5,
           "op": "I",
           "row_id": "5",
@@ -469,6 +475,7 @@ describe("Drizzle test", () => {
         },
         {
           "cursor": 5000004,
+          "indexer_id": "indexer_testing_default",
           "n": 6,
           "op": "U",
           "row_id": "5",
@@ -484,6 +491,7 @@ describe("Drizzle test", () => {
         },
         {
           "cursor": 5000005,
+          "indexer_id": "indexer_testing_default",
           "n": 7,
           "op": "I",
           "row_id": "6",
@@ -492,6 +500,7 @@ describe("Drizzle test", () => {
         },
         {
           "cursor": 5000009,
+          "indexer_id": "indexer_testing_default",
           "n": 13,
           "op": "I",
           "row_id": "10",
@@ -508,9 +517,7 @@ describe("Drizzle test", () => {
 
     const indexer = getMockIndexer({
       override: {
-        plugins: [
-          drizzleStorage({ db, persistState: true, indexerName: "testing" }),
-        ],
+        plugins: [drizzleStorage({ db, persistState: true })],
         async transform({ endCursor, block: { data } }) {
           const { db: tx } = useDrizzleStorage(db);
 
@@ -632,9 +639,7 @@ describe("Drizzle test", () => {
 
     const indexer = getMockIndexer({
       override: {
-        plugins: [
-          drizzleStorage({ db, persistState: true, indexerName: "testing" }),
-        ],
+        plugins: [drizzleStorage({ db, persistState: true })],
         async transform({ endCursor, block: { data } }) {
           const { db: tx } = useDrizzleStorage(db);
 
@@ -673,7 +678,7 @@ describe("Drizzle test", () => {
     expect(checkpointsResult).toMatchInlineSnapshot(`
       [
         {
-          "id": "testing",
+          "id": "indexer_testing_default",
           "orderKey": 5000005,
           "uniqueKey": "",
         },
@@ -815,9 +820,7 @@ describe("Drizzle test", () => {
 
     const indexer = getMockIndexer({
       override: {
-        plugins: [
-          drizzleStorage({ db, persistState: true, indexerName: "testing" }),
-        ],
+        plugins: [drizzleStorage({ db, persistState: true })],
         startingCursor: { orderKey: 100n },
         factory: async ({ block }) => {
           if (block.data === "B") {
@@ -841,7 +844,7 @@ describe("Drizzle test", () => {
     expect(checkpointsResult).toMatchInlineSnapshot(`
       [
         {
-          "id": "testing",
+          "id": "indexer_testing_default",
           "orderKey": 108,
           "uniqueKey": "",
         },
@@ -854,7 +857,7 @@ describe("Drizzle test", () => {
       	"filter": "B"
       }",
           "fromBlock": 103,
-          "id": "testing",
+          "id": "indexer_testing_default",
           "toBlock": 106,
         },
         {
@@ -862,7 +865,7 @@ describe("Drizzle test", () => {
       	"filter": "BC"
       }",
           "fromBlock": 106,
-          "id": "testing",
+          "id": "indexer_testing_default",
           "toBlock": null,
         },
       ]
@@ -1001,9 +1004,7 @@ describe("Drizzle test", () => {
 
     const indexer = getMockIndexer({
       override: {
-        plugins: [
-          drizzleStorage({ db, persistState: true, indexerName: "testing" }),
-        ],
+        plugins: [drizzleStorage({ db, persistState: true })],
         startingCursor: { orderKey: 100n },
         factory: async ({ block }) => {
           if (block.data === "B") {
@@ -1027,7 +1028,7 @@ describe("Drizzle test", () => {
     expect(checkpointsResult).toMatchInlineSnapshot(`
       [
         {
-          "id": "testing",
+          "id": "indexer_testing_default",
           "orderKey": 107,
           "uniqueKey": "",
         },
@@ -1040,7 +1041,7 @@ describe("Drizzle test", () => {
       	"filter": "B"
       }",
           "fromBlock": 103,
-          "id": "testing",
+          "id": "indexer_testing_default",
           "toBlock": null,
         },
       ]
@@ -1179,9 +1180,7 @@ describe("Drizzle test", () => {
 
     const indexer = getMockIndexer({
       override: {
-        plugins: [
-          drizzleStorage({ db, persistState: true, indexerName: "testing" }),
-        ],
+        plugins: [drizzleStorage({ db, persistState: true })],
         startingCursor: { orderKey: 100n },
         factory: async ({ block }) => {
           if (block.data === "B") {
@@ -1205,7 +1204,7 @@ describe("Drizzle test", () => {
     expect(checkpointsResult).toMatchInlineSnapshot(`
       [
         {
-          "id": "testing",
+          "id": "indexer_testing_default",
           "orderKey": 107,
           "uniqueKey": "",
         },
@@ -1218,7 +1217,7 @@ describe("Drizzle test", () => {
       	"filter": "BC"
       }",
           "fromBlock": 106,
-          "id": "testing",
+          "id": "indexer_testing_default",
           "toBlock": null,
         },
       ]
@@ -1230,9 +1229,7 @@ describe("Drizzle test", () => {
 
     const indexer = getMockIndexer({
       override: {
-        plugins: [
-          drizzleStorage({ db, persistState: true, indexerName: "testing" }),
-        ],
+        plugins: [drizzleStorage({ db, persistState: true })],
         async transform({ endCursor, block: { data } }) {
           const { db: tx } = useDrizzleStorage(db);
 

--- a/packages/plugin-mongo/tests/storage.test.ts
+++ b/packages/plugin-mongo/tests/storage.test.ts
@@ -2,7 +2,7 @@ import { run } from "@apibara/indexer";
 import {
   generateMockMessages,
   getMockIndexer,
-} from "@apibara/indexer/internal";
+} from "@apibara/indexer/internal/testing";
 import {
   type MockBlock,
   MockClient,
@@ -10,6 +10,7 @@ import {
 } from "@apibara/protocol/testing";
 import { describe, expect, it } from "vitest";
 
+import { generateIndexerId } from "@apibara/indexer/internal";
 import type { Finalize, Invalidate } from "@apibara/protocol";
 import { MongoClient } from "mongodb";
 import { mongoStorage, useMongoStorage } from "../src";
@@ -30,6 +31,8 @@ type TestSchema = {
     to: number | null;
   };
 };
+
+const indexerId = generateIndexerId("testing");
 
 describe("MongoDB Test", () => {
   it("should store data with a cursor", async () => {
@@ -366,7 +369,6 @@ describe("MongoDB Test", () => {
 
   it("should persist state", async () => {
     const { db, client, dbName } = getRandomDatabase();
-    const indexerName = "persist-test";
 
     const indexer = getMockIndexer({
       override: {
@@ -376,7 +378,6 @@ describe("MongoDB Test", () => {
             dbName,
             collections: ["test"],
             persistState: true,
-            indexerName,
           }),
         ],
         async transform({ endCursor }) {
@@ -420,7 +421,7 @@ describe("MongoDB Test", () => {
       const persistence = await getState({
         db,
         session,
-        indexerName,
+        indexerId,
       });
       expect(persistence).toMatchInlineSnapshot(`
         {
@@ -436,7 +437,6 @@ describe("MongoDB Test", () => {
 
   it("should persist the filters and latest block number (factory mode)", async () => {
     const { db, client, dbName } = getRandomDatabase();
-    const indexerName = "persist-test";
 
     const mockClient = new MockClient<MockFilter, MockBlock>(
       (request, options) => {
@@ -568,16 +568,15 @@ describe("MongoDB Test", () => {
     );
 
     const indexer = getMockIndexer({
-      plugins: [
-        mongoStorage({
-          client,
-          dbName,
-          collections: ["test"],
-          persistState: true,
-          indexerName,
-        }),
-      ],
       override: {
+        plugins: [
+          mongoStorage({
+            client,
+            dbName,
+            collections: ["test"],
+            persistState: true,
+          }),
+        ],
         startingCursor: { orderKey: 100n },
         factory: async ({ block }) => {
           if (block.data === "B") {
@@ -609,7 +608,7 @@ describe("MongoDB Test", () => {
     ).toMatchInlineSnapshot(`
       [
         {
-          "id": "persist-test",
+          "id": "indexer_testing_default",
           "orderKey": 108,
           "uniqueKey": null,
         },
@@ -622,7 +621,7 @@ describe("MongoDB Test", () => {
             "filter": "B",
           },
           "fromBlock": 103,
-          "id": "persist-test",
+          "id": "indexer_testing_default",
           "toBlock": 106,
         },
         {
@@ -630,7 +629,7 @@ describe("MongoDB Test", () => {
             "filter": "BC",
           },
           "fromBlock": 106,
-          "id": "persist-test",
+          "id": "indexer_testing_default",
           "toBlock": null,
         },
       ]
@@ -769,16 +768,15 @@ describe("MongoDB Test", () => {
     );
 
     const indexer = getMockIndexer({
-      plugins: [
-        mongoStorage({
-          client,
-          dbName,
-          collections: ["test"],
-          persistState: true,
-          indexerName,
-        }),
-      ],
       override: {
+        plugins: [
+          mongoStorage({
+            client,
+            dbName,
+            collections: ["test"],
+            persistState: true,
+          }),
+        ],
         startingCursor: { orderKey: 100n },
         factory: async ({ block }) => {
           if (block.data === "B") {
@@ -810,7 +808,7 @@ describe("MongoDB Test", () => {
     ).toMatchInlineSnapshot(`
       [
         {
-          "id": "persist-test",
+          "id": "indexer_testing_default",
           "orderKey": 107,
           "uniqueKey": null,
         },
@@ -823,7 +821,7 @@ describe("MongoDB Test", () => {
             "filter": "B",
           },
           "fromBlock": 103,
-          "id": "persist-test",
+          "id": "indexer_testing_default",
           "toBlock": null,
         },
       ]
@@ -962,16 +960,15 @@ describe("MongoDB Test", () => {
     );
 
     const indexer = getMockIndexer({
-      plugins: [
-        mongoStorage({
-          client,
-          dbName,
-          collections: ["test"],
-          persistState: true,
-          indexerName,
-        }),
-      ],
       override: {
+        plugins: [
+          mongoStorage({
+            client,
+            dbName,
+            collections: ["test"],
+            persistState: true,
+          }),
+        ],
         startingCursor: { orderKey: 100n },
         factory: async ({ block }) => {
           if (block.data === "B") {
@@ -1003,7 +1000,7 @@ describe("MongoDB Test", () => {
     ).toMatchInlineSnapshot(`
       [
         {
-          "id": "persist-test",
+          "id": "indexer_testing_default",
           "orderKey": 107,
           "uniqueKey": null,
         },
@@ -1016,7 +1013,7 @@ describe("MongoDB Test", () => {
             "filter": "BC",
           },
           "fromBlock": 106,
-          "id": "persist-test",
+          "id": "indexer_testing_default",
           "toBlock": null,
         },
       ]

--- a/packages/plugin-sqlite/src/utils.ts
+++ b/packages/plugin-sqlite/src/utils.ts
@@ -4,8 +4,8 @@ export type SerializeFn = <T>(value: T) => string;
 export type DeserializeFn = <T>(value: string) => T;
 
 export class SqliteStorageError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = "SqliteStorageError";
   }
 }
@@ -44,4 +44,8 @@ export function serialize<T>(obj: T): string {
     (_, value) => (typeof value === "bigint" ? `${value.toString()}n` : value),
     "\t",
   );
+}
+
+export function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/plugin-sqlite/tests/kv.test.ts
+++ b/packages/plugin-sqlite/tests/kv.test.ts
@@ -2,7 +2,7 @@ import { run } from "@apibara/indexer";
 import {
   generateMockMessages,
   getMockIndexer,
-} from "@apibara/indexer/internal";
+} from "@apibara/indexer/internal/testing";
 import {
   type MockBlock,
   MockClient,
@@ -236,8 +236,8 @@ describe("SQLite key-value store", () => {
     });
 
     const indexer = getMockIndexer({
-      plugins: [sqliteStorage({ database: db, keyValueStore: true })],
       override: {
+        plugins: [sqliteStorage({ database: db, keyValueStore: true })],
         startingCursor: { orderKey: 100n },
         factory: async ({ block }) => {
           if (block.data === "B") {
@@ -414,8 +414,8 @@ describe("SQLite key-value store", () => {
     });
 
     const indexer = getMockIndexer({
-      plugins: [sqliteStorage({ database: db, keyValueStore: true })],
       override: {
+        plugins: [sqliteStorage({ database: db, keyValueStore: true })],
         startingCursor: { orderKey: 100n },
         factory: async ({ block }) => {
           if (block.data === "B") {

--- a/packages/plugin-sqlite/tests/persistence.test.ts
+++ b/packages/plugin-sqlite/tests/persistence.test.ts
@@ -2,7 +2,7 @@ import { run } from "@apibara/indexer";
 import {
   generateMockMessages,
   getMockIndexer,
-} from "@apibara/indexer/internal";
+} from "@apibara/indexer/internal/testing";
 import {
   type MockBlock,
   MockClient,
@@ -14,7 +14,6 @@ import { describe, expect, it } from "vitest";
 import type { Finalize, Invalidate } from "@apibara/protocol";
 import { sqliteStorage } from "../src";
 
-const indexerName = "test-indexer";
 describe("SQLite persistence", () => {
   it("should store the latest block number", async () => {
     const db = new Database(":memory:");
@@ -25,7 +24,7 @@ describe("SQLite persistence", () => {
 
     const indexer = getMockIndexer({
       override: {
-        plugins: [sqliteStorage({ database: db, indexerName })],
+        plugins: [sqliteStorage({ database: db })],
       },
     });
 
@@ -36,7 +35,7 @@ describe("SQLite persistence", () => {
     expect(rows).toMatchInlineSnapshot(`
       [
         {
-          "id": "test-indexer",
+          "id": "indexer_testing_default",
           "order_key": 5000002,
           "unique_key": null,
         },
@@ -175,10 +174,8 @@ describe("SQLite persistence", () => {
     });
 
     const indexer = getMockIndexer({
-      plugins: [
-        sqliteStorage({ database: db, persistState: true, indexerName }),
-      ],
       override: {
+        plugins: [sqliteStorage({ database: db, persistState: true })],
         startingCursor: { orderKey: 100n },
         factory: async ({ block }) => {
           if (block.data === "B") {
@@ -202,7 +199,7 @@ describe("SQLite persistence", () => {
     expect(checkpointsRows).toMatchInlineSnapshot(`
       [
         {
-          "id": "test-indexer",
+          "id": "indexer_testing_default",
           "order_key": 108,
           "unique_key": null,
         },
@@ -215,7 +212,7 @@ describe("SQLite persistence", () => {
       	"filter": "B"
       }",
           "from_block": 103,
-          "id": "test-indexer",
+          "id": "indexer_testing_default",
           "to_block": 106,
         },
         {
@@ -223,7 +220,7 @@ describe("SQLite persistence", () => {
       	"filter": "BC"
       }",
           "from_block": 106,
-          "id": "test-indexer",
+          "id": "indexer_testing_default",
           "to_block": null,
         },
       ]
@@ -239,7 +236,7 @@ describe("SQLite persistence", () => {
 
     const indexer = getMockIndexer({
       override: {
-        plugins: [sqliteStorage({ database: db, indexerName })],
+        plugins: [sqliteStorage({ database: db })],
         async transform({ endCursor }) {
           if (endCursor?.orderKey === 5000002n) {
             throw new Error("test");
@@ -255,7 +252,7 @@ describe("SQLite persistence", () => {
     expect(rows).toMatchInlineSnapshot(`
       [
         {
-          "id": "test-indexer",
+          "id": "indexer_testing_default",
           "order_key": 5000001,
           "unique_key": null,
         },
@@ -272,9 +269,7 @@ describe("SQLite persistence", () => {
 
     const indexer = getMockIndexer({
       override: {
-        plugins: [
-          sqliteStorage({ database: db, persistState: false, indexerName }),
-        ],
+        plugins: [sqliteStorage({ database: db, persistState: false })],
       },
     });
 
@@ -412,10 +407,8 @@ describe("SQLite persistence", () => {
     });
 
     const indexer = getMockIndexer({
-      plugins: [
-        sqliteStorage({ database: db, persistState: true, indexerName }),
-      ],
       override: {
+        plugins: [sqliteStorage({ database: db, persistState: true })],
         startingCursor: { orderKey: 100n },
         factory: async ({ block }) => {
           if (block.data === "B") {
@@ -439,7 +432,7 @@ describe("SQLite persistence", () => {
     expect(checkpointsRows).toMatchInlineSnapshot(`
       [
         {
-          "id": "test-indexer",
+          "id": "indexer_testing_default",
           "order_key": 107,
           "unique_key": null,
         },
@@ -452,7 +445,7 @@ describe("SQLite persistence", () => {
       	"filter": "B"
       }",
           "from_block": 103,
-          "id": "test-indexer",
+          "id": "indexer_testing_default",
           "to_block": null,
         },
       ]
@@ -588,10 +581,8 @@ describe("SQLite persistence", () => {
     });
 
     const indexer = getMockIndexer({
-      plugins: [
-        sqliteStorage({ database: db, persistState: true, indexerName }),
-      ],
       override: {
+        plugins: [sqliteStorage({ database: db, persistState: true })],
         startingCursor: { orderKey: 100n },
         factory: async ({ block }) => {
           if (block.data === "B") {
@@ -615,7 +606,7 @@ describe("SQLite persistence", () => {
     expect(checkpointsRows).toMatchInlineSnapshot(`
       [
         {
-          "id": "test-indexer",
+          "id": "indexer_testing_default",
           "order_key": 107,
           "unique_key": null,
         },
@@ -628,7 +619,7 @@ describe("SQLite persistence", () => {
       	"filter": "BC"
       }",
           "from_block": 106,
-          "id": "test-indexer",
+          "id": "indexer_testing_default",
           "to_block": null,
         },
       ]


### PR DESCRIPTION
Resolves #140 

- adds a `internalContext` plugin for runtime purpose
- adds a `generateIndexerId` util method
- fixes concurrency issue in creation of tables in parallel transactions in drizzle plugin
- updates test and plugins for the above