### PR TITLE
cli: remove esbuild plugin from rollup config

### DIFF
--- a/change/@apibara-indexer-7d0fe9aa-5dc3-4ba2-96c2-26a750edd3ec.json
+++ b/change/@apibara-indexer-7d0fe9aa-5dc3-4ba2-96c2-26a750edd3ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "indexer: add internalContext plugin to vcr",
+  "packageName": "@apibara/indexer",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/apibara-613baa45-cb22-4333-9430-93f356634a9a.json
+++ b/change/apibara-613baa45-cb22-4333-9430-93f356634a9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "cli: remove esbuild plugin from rollup",
+  "packageName": "apibara",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/examples/cli/test/ethereum.test.ts
+++ b/examples/cli/test/ethereum.test.ts
@@ -32,104 +32,41 @@ describe("Ethereum USDC Transfers indexer", () => {
     });
     const rows = await database.select().from(ethereumUsdcTransfers);
 
-    expect(rows).toMatchInlineSnapshot(`
+    expect(rows.map(({ _id, ...rest }) => rest)).toMatchInlineSnapshot(`
       [
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 10000001,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0xfc80de5a3b766eece5c5a7f7858a9d537a8fefa8186c71fa7766a2bae939b816",
           "number": 10000001,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 10000001,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x8a38d2a2de4821f6d13d393c364fced4b0280dc66976cd43b7f9c3dd4aeebae6",
           "number": 10000001,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 10000002,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0xa20537a561c41855e6719f687d060217cfe105f6314c2facd68accbb197b7a72",
           "number": 10000002,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 10000002,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0xec921d30995ee6e19c67712d264311fffc1936262d6bc99db44e93682866838f",
           "number": 10000002,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 10000003,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x2894671b55148dc194b9ad859ca231fa3ff8a7e0a3cde2e5c7bb21915a448104",
           "number": 10000003,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 10000003,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x77b58d6769d43bd21379dea89d65bd860127753de7e7b607cec267d4ddcbf9c6",
           "number": 10000003,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 10000003,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x46d3e295575268ddb5cb778d52dd2b2f66e6e4dc984bdaa1b3ae8459d3c0ccb3",
           "number": 10000003,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 10000003,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x0862e1e01a91390133574765808540617de4dc3faf66c3acc6b45fe3eb478b0d",
           "number": 10000003,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 10000005,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0xd50111f6b29419d975446d9f1ce05386f4778a1532ab43267e88f33fb71e01e2",
           "number": 10000005,
         },

--- a/examples/cli/test/starknet.test.ts
+++ b/examples/cli/test/starknet.test.ts
@@ -32,148 +32,57 @@ describe("Starknet USDC Transfers indexer", () => {
     });
     const rows = await database.select().from(starknetUsdcTransfers);
 
-    expect(rows).toMatchInlineSnapshot(`
+    expect(rows.map(({ _id, ...rest }) => rest)).toMatchInlineSnapshot(`
       [
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 800001,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x006dcfffad0aebb8e496bf1af95b97ab181e9b86bd61a07c2926407ea70c0d0e",
           "number": 800001,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 800002,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x07b2c7d48d92eb6110b5039a112110b4ee5b59b9249764d22441c988f2a3730d",
           "number": 800002,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 800002,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x0288e4f00a93f4ea8f61bc0c218df8070c2a4ecd219e18a8fe39d473e62dff08",
           "number": 800002,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 800002,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x029959d46cfadb2b0c8cc823a9e4c03b7f22f8c596c424c9e11db62ee7fa96ba",
           "number": 800002,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 800002,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x0247f793e0525ed7d9d369b1b701942e55c4d41a3116733f0c77af3c0dfd21ad",
           "number": 800002,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 800002,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x06683c568f2e977e3d4b6f4da70b3926950c83f5a7c6119b3f2a643643db8fed",
           "number": 800002,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 800002,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x041a41f4fdda921c6049188312aaaa28f63e6bb628d6dd604891449d4d76b395",
           "number": 800002,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 800002,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x0393e0fbc25313322c088d5d457961f72bf6f6f31cc846f3e8aa96c1e53922c3",
           "number": 800002,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 800002,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x05042aeb03be2ec2ae48d78dcc69e9d79221807cc70eedcf083db70adfd88eac",
           "number": 800002,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 800002,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x06ecfe783686b0dc2747acfcc77e7dcda2b2baea6e65bc8624537e14ca024343",
           "number": 800002,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 800003,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x0359aeed2843c282006cff7326fdce682efd3e6c43170df8fad02f1e0d1a9446",
           "number": 800003,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 800004,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x0725361f6a2bafeb496b0b879ed7711d8ae3afd9dfd973bfac97ff0e3cb0cd4b",
           "number": 800004,
         },
         {
-          "_cursor": Int8Range {
-            "range": Range {
-              "lower": 800005,
-              "mask": 36,
-              "upper": null,
-            },
-          },
           "hash": "0x079bdefcacc75dd1db6dfcdf3b29e9c30d2b70002d9d85a3d1b2032e2c72251c",
           "number": 800005,
         },

--- a/examples/starknet-client/package.json
+++ b/examples/starknet-client/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.12.12",
-    "jiti": "^1.21.0"
+    "jiti": "^1.21.0",
+    "typescript": "^5.6.2"
   }
 }

--- a/packages/cli/src/rollup/config.ts
+++ b/packages/cli/src/rollup/config.ts
@@ -5,7 +5,6 @@ import { nodeResolve } from "@rollup/plugin-node-resolve";
 import type { Apibara, RollupConfig } from "apibara/types";
 import { join } from "pathe";
 import type { OutputPluginOption } from "rollup";
-import esbuild from "rollup-plugin-esbuild";
 
 import defu from "defu";
 import { appConfig } from "./plugins/config";
@@ -52,7 +51,8 @@ export function getRollupConfig(apibara: Apibara): RollupConfig {
             warning.code || "",
           ) &&
           !warning.message.includes("Unsupported source map comment") &&
-          !warning.message.includes("@__PURE__")
+          !warning.message.includes("@__PURE__") &&
+          !warning.message.includes("/*#__PURE__*/")
         ) {
           rollupWarn(warning);
         }
@@ -80,14 +80,6 @@ export function getRollupConfig(apibara: Apibara): RollupConfig {
       mainFields: ["main"],
     }),
   );
-
-  rollupConfig.plugins.push(
-    esbuild({
-      target: "es2022",
-      sourceMap: apibara.options.sourceMap,
-    }),
-  );
-
   rollupConfig.plugins.push(indexers(apibara));
   rollupConfig.plugins.push(appConfig(apibara));
 

--- a/packages/indexer/src/plugins/context.ts
+++ b/packages/indexer/src/plugins/context.ts
@@ -30,8 +30,11 @@ export type InternalContext = {
 
 export function useInternalContext(): InternalContext {
   const ctx = useIndexerContext();
-  if (!ctx[INTERNAL_CONTEXT_PROPERTY]) {
-    throw new Error("Internal context is not available");
+
+  if (ctx[INTERNAL_CONTEXT_PROPERTY] === undefined) {
+    throw new Error(
+      "Internal context is not available, possibly 'internalContext' plugin is missing!",
+    );
   }
   return ctx[INTERNAL_CONTEXT_PROPERTY];
 }

--- a/packages/indexer/src/testing/index.ts
+++ b/packages/indexer/src/testing/index.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@apibara/protocol";
 import ci from "ci-info";
 import { type IndexerWithStreamConfig, createIndexer } from "../indexer";
+import { type InternalContext, internalContext } from "../plugins/context";
 import { logger } from "../plugins/logger";
 import type { CassetteOptions, VcrConfig } from "../vcr/config";
 import { isCassetteAvailable } from "../vcr/helper";
@@ -28,7 +29,14 @@ export function createVcr() {
         },
       };
 
-      indexerConfig.plugins = [logger(), ...(indexerConfig.plugins ?? [])];
+      indexerConfig.plugins = [
+        internalContext({
+          indexerName: cassetteName,
+          availableIndexers: [cassetteName],
+        } as InternalContext),
+        logger(),
+        ...(indexerConfig.plugins ?? []),
+      ];
 
       const indexer = createIndexer(indexerConfig);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       jiti:
         specifier: ^1.21.0
         version: 1.21.0
+      typescript:
+        specifier: ^5.6.2
+        version: 5.6.2
 
   packages/beaconchain:
     dependencies:


### PR DESCRIPTION
removes `esbuild` plugin from rollup config due to some issues with build, also adds missing `internalContext` plugin from `vcr` and updates tests for `cli` example.