### PR TITLE
Fix deserialization issue with drizzle cursor

### DIFF
--- a/change/@apibara-beaconchain-7b39a030-0724-44c0-8cec-7300e5efa49b.json
+++ b/change/@apibara-beaconchain-7b39a030-0724-44c0-8cec-7300e5efa49b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugins: fix issue caused by cursors with empty unique key",
+  "packageName": "@apibara/beaconchain",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-evm-c96dd7a5-d16a-44aa-ac3a-947a9b904517.json
+++ b/change/@apibara-evm-c96dd7a5-d16a-44aa-ac3a-947a9b904517.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugins: fix issue caused by cursors with empty unique key",
+  "packageName": "@apibara/evm",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-plugin-drizzle-c4aaf5bc-24c6-4883-9b29-cf614279c5db.json
+++ b/change/@apibara-plugin-drizzle-c4aaf5bc-24c6-4883-9b29-cf614279c5db.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugin-drizzle: fix issue caused by cursors with empty unique key",
+  "packageName": "@apibara/plugin-drizzle",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-plugin-mongo-ddb9c304-419b-4291-bb27-6c198e0501cd.json
+++ b/change/@apibara-plugin-mongo-ddb9c304-419b-4291-bb27-6c198e0501cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugins: fix issue caused by cursors with empty unique key",
+  "packageName": "@apibara/plugin-mongo",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-plugin-sqlite-ab552e08-0770-4528-b9a9-f1ffb9e0105f.json
+++ b/change/@apibara-plugin-sqlite-ab552e08-0770-4528-b9a9-f1ffb9e0105f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugins: fix issue caused by cursors with empty unique key",
+  "packageName": "@apibara/plugin-sqlite",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-protocol-c3b43226-48fe-4e9f-abe7-760ca8e09b82.json
+++ b/change/@apibara-protocol-c3b43226-48fe-4e9f-abe7-760ca8e09b82.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugins: fix issue caused by cursors with empty unique key",
+  "packageName": "@apibara/protocol",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
           "packages/evm",
           "packages/indexer",
           "packages/protocol",
-          "packages/starknet"
+          "packages/starknet",
+          "packages/plugin-drizzle",
+          "packages/plugin-mongo",
+          "packages/plugin-sqlite"
         ]
       }
     ],

--- a/packages/beaconchain/package.json
+++ b/packages/beaconchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apibara/beaconchain",
-  "version": "2.0.1-beta.31",
+  "version": "2.0.1-beta.39",
   "type": "module",
   "files": [
     "dist",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apibara/evm",
-  "version": "2.0.1-beta.31",
+  "version": "2.0.1-beta.39",
   "type": "module",
   "files": [
     "dist",

--- a/packages/plugin-drizzle/package.json
+++ b/packages/plugin-drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apibara/plugin-drizzle",
-  "version": "2.0.0-beta.38",
+  "version": "2.0.0-beta.39",
   "type": "module",
   "files": [
     "dist",

--- a/packages/plugin-drizzle/tests/storage.test.ts
+++ b/packages/plugin-drizzle/tests/storage.test.ts
@@ -680,7 +680,7 @@ describe("Drizzle test", () => {
         {
           "id": "indexer_testing_default",
           "orderKey": 5000005,
-          "uniqueKey": "",
+          "uniqueKey": null,
         },
       ]
     `);
@@ -846,7 +846,7 @@ describe("Drizzle test", () => {
         {
           "id": "indexer_testing_default",
           "orderKey": 108,
-          "uniqueKey": "",
+          "uniqueKey": null,
         },
       ]
     `);
@@ -1030,7 +1030,7 @@ describe("Drizzle test", () => {
         {
           "id": "indexer_testing_default",
           "orderKey": 107,
-          "uniqueKey": "",
+          "uniqueKey": null,
         },
       ]
     `);
@@ -1206,7 +1206,7 @@ describe("Drizzle test", () => {
         {
           "id": "indexer_testing_default",
           "orderKey": 107,
-          "uniqueKey": "",
+          "uniqueKey": null,
         },
       ]
     `);

--- a/packages/plugin-mongo/src/persistence.ts
+++ b/packages/plugin-mongo/src/persistence.ts
@@ -1,10 +1,10 @@
-import type { Cursor } from "@apibara/protocol";
+import { type Cursor, normalizeCursor } from "@apibara/protocol";
 import type { ClientSession, Db } from "mongodb";
 
 export type CheckpointSchema = {
   id: string;
   orderKey: number;
-  uniqueKey?: `0x${string}`;
+  uniqueKey: string | null;
 };
 
 export type FilterSchema = {
@@ -98,10 +98,10 @@ export async function getState<TFilter>(props: {
     .findOne({ id: indexerId }, { session });
 
   if (checkpointRow) {
-    cursor = {
+    cursor = normalizeCursor({
       orderKey: BigInt(checkpointRow.orderKey),
       uniqueKey: checkpointRow.uniqueKey,
-    };
+    });
   }
 
   const filterRow = await db

--- a/packages/plugin-mongo/tests/storage.test.ts
+++ b/packages/plugin-mongo/tests/storage.test.ts
@@ -427,7 +427,6 @@ describe("MongoDB Test", () => {
         {
           "cursor": {
             "orderKey": 5000005n,
-            "uniqueKey": null,
           },
           "filter": undefined,
         }

--- a/packages/plugin-sqlite/package.json
+++ b/packages/plugin-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apibara/plugin-sqlite",
-  "version": "2.0.0-beta.38",
+  "version": "2.0.0-beta.39",
   "type": "module",
   "files": [
     "dist",

--- a/packages/plugin-sqlite/src/persistence.ts
+++ b/packages/plugin-sqlite/src/persistence.ts
@@ -1,4 +1,4 @@
-import type { Cursor } from "@apibara/protocol";
+import { type Cursor, normalizeCursor } from "@apibara/protocol";
 import type { Database } from "better-sqlite3";
 
 import { assertInTransaction, deserialize, serialize } from "./utils";
@@ -57,10 +57,10 @@ export function getState<TFilter>(props: {
   let filter: TFilter | undefined;
 
   if (storedCursor?.order_key) {
-    cursor = {
+    cursor = normalizeCursor({
       orderKey: BigInt(storedCursor.order_key),
-      uniqueKey: storedCursor.unique_key as `0x${string}`,
-    };
+      uniqueKey: storedCursor.unique_key ? storedCursor.unique_key : null,
+    });
   }
 
   if (storedFilter) {

--- a/packages/protocol/src/common.ts
+++ b/packages/protocol/src/common.ts
@@ -67,3 +67,27 @@ export const cursorFromBytes = Schema.decodeSync(CursorFromBytes);
 export function isCursor(value: unknown): value is Cursor {
   return Schema.is(Cursor)(value);
 }
+
+/** Normalize a cursor.
+ *
+ * The challenge is that the `Cursor` validator expects `uniqueKey` to be either a `0x${string}`
+ * or not present at all. Setting the field to `undefined` will result in a validation error.
+ *
+ * @param cursor The cursor to normalize
+ */
+export function normalizeCursor(cursor: {
+  orderKey: bigint;
+  uniqueKey: string | null;
+}): Cursor {
+  if (cursor.uniqueKey !== null && cursor.uniqueKey.length > 0) {
+    const uniqueKey = cursor.uniqueKey as `0x${string}`;
+    return {
+      orderKey: BigInt(cursor.orderKey),
+      uniqueKey,
+    };
+  }
+
+  return {
+    orderKey: BigInt(cursor.orderKey),
+  };
+}


### PR DESCRIPTION
If the stored cursor has an empty uniqueKey, it's serialized as an empty string. This is an issue later when deserializing since that's not a valid value for the uniqueKey.
