### PR TITLE
cli: add file formatting with prettier and add noIndexer flag

### DIFF
--- a/change/@apibara-indexer-b2bba30d-fe14-4236-830e-49c35d5e973a.json
+++ b/change/@apibara-indexer-b2bba30d-fe14-4236-830e-49c35d5e973a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "indexer: fix startingBlock validation",
+  "packageName": "@apibara/indexer",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/apibara-f4a63aad-bcfe-435c-9522-12e7c8c95a4e.json
+++ b/change/apibara-f4a63aad-bcfe-435c-9522-12e7c8c95a4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "cli: prettier formatting and noIndexer flag",
+  "packageName": "apibara",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -109,6 +109,7 @@
     "perfect-debounce": "^1.0.0",
     "picocolors": "^1.1.1",
     "pkg-types": "^1.1.3",
+    "prettier": "^3.5.2",
     "prompts": "^2.4.2",
     "rollup": "^4.18.1",
     "rollup-plugin-esbuild": "^6.1.1",

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -18,23 +18,19 @@ export default defineCommand({
       default: "ts",
       alias: "l",
     },
-    "no-create-indexer": {
+    noIndexer: {
       type: "boolean",
       description: "Do not create an indexer after initialization",
       default: false,
     },
   },
   async run({ args }) {
-    const {
-      dir: targetDir,
-      "no-create-indexer": noCreateIndexer,
-      language,
-    } = args;
+    const { dir: targetDir, noIndexer, language } = args;
 
     await initializeProject({
       argTargetDir: targetDir,
       argLanguage: language,
-      argNoCreateIndexer: noCreateIndexer,
+      argNoCreateIndexer: noIndexer,
     });
   },
 });

--- a/packages/cli/src/create/constants.ts
+++ b/packages/cli/src/create/constants.ts
@@ -66,17 +66,17 @@ export const storages: StorageDataType[] = [
 
 export const packageVersions = {
   // Required Dependencies
-  apibara: "^2.1.0-beta.1",
-  "@apibara/indexer": "^2.1.0-beta.1",
-  "@apibara/protocol": "^2.1.0-beta.1",
+  apibara: "^2.1.0-beta.2",
+  "@apibara/indexer": "^2.1.0-beta.2",
+  "@apibara/protocol": "^2.1.0-beta.2",
   // Chain Dependencies
-  "@apibara/evm": "^2.1.0-beta.1",
-  "@apibara/beaconchain": "^2.1.0-beta.1",
-  "@apibara/starknet": "^2.1.0-beta.1",
+  "@apibara/evm": "^2.1.0-beta.2",
+  "@apibara/beaconchain": "^2.1.0-beta.2",
+  "@apibara/starknet": "^2.1.0-beta.2",
   // Storage Dependencies
-  "@apibara/plugin-drizzle": "^2.1.0-beta.1",
-  "@apibara/plugin-mongo": "^2.1.0-beta.1",
-  "@apibara/plugin-sqlite": "^2.1.0-beta.1",
+  "@apibara/plugin-drizzle": "^2.1.0-beta.2",
+  "@apibara/plugin-mongo": "^2.1.0-beta.2",
+  "@apibara/plugin-sqlite": "^2.1.0-beta.2",
   // Postgres Dependencies
   "@electric-sql/pglite": "^0.2.17",
   "drizzle-orm": "^0.37.0",

--- a/packages/cli/src/create/init.ts
+++ b/packages/cli/src/create/init.ts
@@ -13,6 +13,7 @@ import type { Language } from "./types";
 import {
   cancelOperation,
   emptyDir,
+  formatFile,
   getLanguageFromAlias,
   getPackageManager,
   isEmpty,
@@ -121,30 +122,40 @@ export async function initializeProject({
   consola.info(`Initializing project in ${argTargetDir}\n\n`);
 
   // Generate package.json
+  const packageJsonPath = path.join(root, "package.json");
   const packageJson = generatePackageJson(isTs);
   fs.writeFileSync(
-    path.join(root, "package.json"),
+    packageJsonPath,
     JSON.stringify(packageJson, null, 2) + "\n",
   );
+  await formatFile(packageJsonPath);
   consola.success("Created ", cyan("package.json"));
 
   // Generate tsconfig.json if TypeScript
   if (isTs) {
+    const tsConfigPath = path.join(root, "tsconfig.json");
     const tsConfig = generateTsConfig();
-    fs.writeFileSync(
-      path.join(root, "tsconfig.json"),
-      JSON.stringify(tsConfig, null, 2) + "\n",
-    );
+    fs.writeFileSync(tsConfigPath, JSON.stringify(tsConfig, null, 2) + "\n");
+    await formatFile(tsConfigPath);
     consola.success("Created ", cyan("tsconfig.json"));
   }
 
+  const apibaraConfigPath = path.join(root, `apibara.config.${configExt}`);
   // Generate apibara.config
   const apibaraConfig = generateApibaraConfig(isTs);
-  fs.writeFileSync(
-    path.join(root, `apibara.config.${configExt}`),
-    apibaraConfig,
-  );
-  consola.success("Created ", cyan(`apibara.config.${configExt}`), "\n\n");
+  fs.writeFileSync(apibaraConfigPath, apibaraConfig);
+  await formatFile(apibaraConfigPath);
+  consola.success("Created ", cyan(`apibara.config.${configExt}`));
+
+  // Create "indexers" directory if not exists
+  const indexersDir = path.join(root, "indexers");
+  if (!fs.existsSync(indexersDir)) {
+    fs.mkdirSync(indexersDir, { recursive: true });
+    consola.success(`Created ${cyan("indexers")} directory`);
+  }
+
+  console.log("\n");
+
   consola.ready(green("Project initialized successfully"));
 
   console.log();

--- a/packages/cli/src/create/utils.ts
+++ b/packages/cli/src/create/utils.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path, { basename } from "node:path";
+import * as prettier from "prettier";
 import prompts from "prompts";
 import { blue, cyan, red, yellow } from "./colors";
 import { dnaUrls, networks } from "./constants";
@@ -409,4 +410,13 @@ function pkgFromUserAgent(userAgent: string | undefined): PkgInfo | undefined {
     name: pkgSpecArr[0],
     version: pkgSpecArr[1],
   };
+}
+
+export async function formatFile(path: string) {
+  const file = fs.readFileSync(path, "utf8");
+  const formatted = await prettier.format(file, {
+    filepath: path,
+    tabWidth: 2,
+  });
+  fs.writeFileSync(path, formatted);
 }

--- a/packages/indexer/src/indexer.ts
+++ b/packages/indexer/src/indexer.ts
@@ -225,9 +225,13 @@ export async function run<TFilter, TBlock>(
     if (indexer.options.startingCursor) {
       startingCursor = indexer.options.startingCursor;
     } else if (indexer.options.startingBlock !== undefined) {
-      startingCursor = {
-        orderKey: indexer.options.startingBlock,
-      };
+      if (indexer.options.startingBlock === 0n) {
+        startingCursor = undefined;
+      } else if (indexer.options.startingBlock > 0n) {
+        startingCursor = {
+          orderKey: indexer.options.startingBlock - 1n,
+        };
+      }
     }
 
     // if factory mode we add a empty filter at the end of the filter array.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,49 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
 
+  examples/temp:
+    dependencies:
+      '@apibara/indexer':
+        specifier: workspace:*
+        version: link:../../packages/indexer
+      '@apibara/plugin-drizzle':
+        specifier: workspace:*
+        version: link:../../packages/plugin-drizzle
+      '@apibara/protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
+      '@apibara/starknet':
+        specifier: workspace:*
+        version: link:../../packages/starknet
+      '@electric-sql/pglite':
+        specifier: ^0.2.17
+        version: 0.2.17
+      apibara:
+        specifier: workspace:*
+        version: link:../../packages/cli
+      drizzle-kit:
+        specifier: ^0.29.0
+        version: 0.29.1
+      drizzle-orm:
+        specifier: ^0.37.0
+        version: 0.37.0(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.11)(@types/pg@8.11.10)(better-sqlite3@11.5.0)(pg@8.13.1)(postgres@3.4.4)
+      pg:
+        specifier: ^8.13.1
+        version: 8.13.1
+    devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^11.1.6
+        version: 11.1.6(rollup@4.34.8)(tslib@2.6.3)(typescript@5.6.2)
+      '@types/node':
+        specifier: ^20.5.2
+        version: 20.14.0
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.11.10
+      typescript:
+        specifier: ^5.6.2
+        version: 5.6.2
+
   packages/beaconchain:
     dependencies:
       '@apibara/evm':
@@ -299,6 +342,9 @@ importers:
       pkg-types:
         specifier: ^1.1.3
         version: 1.1.3
+      prettier:
+        specifier: ^3.5.2
+        version: 3.5.2
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -3345,6 +3391,11 @@ packages:
   prebuild-install@7.1.2:
     resolution: {integrity: sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==}
     engines: {node: '>=10'}
+    hasBin: true
+
+  prettier@3.5.2:
+    resolution: {integrity: sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==}
+    engines: {node: '>=14'}
     hasBin: true
 
   pretty-bytes@6.1.1:
@@ -6401,6 +6452,8 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0
+
+  prettier@3.5.2: {}
 
   pretty-bytes@6.1.1: {}
 


### PR DESCRIPTION
adds file formatting with prettier, replaces `--no-create-indexer` flag to `--noIndexer` flag in `apibara init` and adds indexer file existence validation in prompt.
also adds validation for starting cursor in indexer.