### PR TITLE
Fix wrong "install" command in CLI init command

### DIFF
--- a/change/apibara-267c95ee-bca5-40de-9b0f-348952969e0c.json
+++ b/change/apibara-267c95ee-bca5-40de-9b0f-348952969e0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: install command doesn't require 'run'",
+  "packageName": "apibara",
+  "email": "nicolascoquelet@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/create/add.ts
+++ b/packages/cli/src/create/add.ts
@@ -230,5 +230,7 @@ export async function addIndexer({
 
   const baseCommand = `${options.packageManager} install`;
   const tsCommand = `${baseCommand} && ${options.packageManager} run prepare`;
-  consola.info(`Before running the indexer, run ${cyan(language === "typescript" ? tsCommand : baseCommand)}`);
+  consola.info(
+    `Before running the indexer, run ${cyan(language === "typescript" ? tsCommand : baseCommand)}`,
+  );
 }

--- a/packages/cli/src/create/add.ts
+++ b/packages/cli/src/create/add.ts
@@ -228,14 +228,7 @@ export async function addIndexer({
 
   console.log();
 
-  consola.info(
-    `Before running the indexer, run ${cyan(`${options.packageManager}${options.packageManager === "npm" ? " run" : ""} install`)}${
-      language === "typescript"
-        ? " & " +
-          cyan(
-            `${options.packageManager}${options.packageManager === "npm" ? " run" : ""} prepare`,
-          )
-        : ""
-    }`,
-  );
+  const baseCommand = `${options.packageManager} install`;
+  const tsCommand = `${baseCommand} && ${options.packageManager} run prepare`;
+  consola.info(`Before running the indexer, run ${cyan(language === "typescript" ? tsCommand : baseCommand)}`);
 }

--- a/packages/cli/src/create/init.ts
+++ b/packages/cli/src/create/init.ts
@@ -171,9 +171,7 @@ export async function initializeProject({
     const pkgManager = getPackageManager();
     consola.info(
       "Run ",
-      green(
-        `${pkgManager.name}${pkgManager.name === "npm" ? " run" : ""} install`,
-      ),
+      green(`${pkgManager.name} install`),
       " to install all dependencies",
     );
   }


### PR DESCRIPTION
Hi,
When we init a new apibara project with `apibara init` the CLI invite us to run the command `npm run install` but is must be `npm install`.
In addition, I copied and pasted the whole command proposed by CLI without paying too much attention that I need to run install and prepare command separately, and an unexpected behaviour because of the `&`.
I suggest clarifying things a little by using the `&&` operator, thus allowing you to copy/paste the entire command, chaining the install and prepare commands. 
Regards