### PR TITLE
feat: add --alwaysReindex flag in dev mode to reset database state on indexer restarts

### DIFF
--- a/change/@apibara-plugin-drizzle-a8baca91-31a7-4300-a577-67d13ce45e13.json
+++ b/change/@apibara-plugin-drizzle-a8baca91-31a7-4300-a577-67d13ce45e13.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugin-drizzle: add cleanup implementation for alwaysReindex flag",
+  "packageName": "@apibara/plugin-drizzle",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-plugin-mongo-88828ea1-dd82-428c-a257-048728e622d7.json
+++ b/change/@apibara-plugin-mongo-88828ea1-dd82-428c-a257-048728e622d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugin-mongo: add cleanup implementation for alwaysReindex flag",
+  "packageName": "@apibara/plugin-mongo",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/apibara-841ae10e-0109-447d-aa1a-95d763e33824.json
+++ b/change/apibara-841ae10e-0109-447d-aa1a-95d763e33824.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "cli: add alwaysReindex flag to reset database/persistence states on dev restarts",
+  "packageName": "apibara",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/cli/commands/dev.ts
+++ b/packages/cli/src/cli/commands/dev.ts
@@ -26,9 +26,19 @@ export default defineCommand({
       type: "string",
       description: "Preset to use",
     },
+    alwaysReindex: {
+      type: "boolean",
+      default: false,
+      description:
+        "Reindex the indexers from the starting block on every restart (default: false)",
+    },
   },
   async run({ args }) {
     const rootDir = resolve((args.dir || args._dir || ".") as string);
+
+    if (args.alwaysReindex) {
+      process.env.APIBARA_ALWAYS_REINDEX = "true";
+    }
 
     let apibara: Apibara;
     let childProcess: ChildProcess | undefined;

--- a/packages/plugin-drizzle/src/persistence.ts
+++ b/packages/plugin-drizzle/src/persistence.ts
@@ -297,3 +297,24 @@ export async function finalizeState<
     });
   }
 }
+
+export async function resetPersistence<
+  TQueryResult extends PgQueryResultHKT,
+  TFullSchema extends Record<string, unknown> = Record<string, never>,
+  TSchema extends
+    TablesRelationalConfig = ExtractTablesWithRelations<TFullSchema>,
+>(props: {
+  tx: PgTransaction<TQueryResult, TFullSchema, TSchema>;
+  indexerId: string;
+}) {
+  const { tx, indexerId } = props;
+
+  try {
+    await tx.delete(checkpoints).where(eq(checkpoints.id, indexerId));
+    await tx.delete(filters).where(eq(filters.id, indexerId));
+  } catch (error) {
+    throw new DrizzleStorageError("Failed to reset persistence state", {
+      cause: error,
+    });
+  }
+}

--- a/packages/plugin-mongo/src/mongo.ts
+++ b/packages/plugin-mongo/src/mongo.ts
@@ -49,3 +49,18 @@ export async function finalize(
     );
   }
 }
+
+export async function cleanupStorage(
+  db: Db,
+  session: ClientSession,
+  collections: string[],
+) {
+  for (const collection of collections) {
+    try {
+      // Delete all documents in the collection
+      await db.collection(collection).deleteMany({}, { session });
+    } catch (error) {
+      throw new Error(`Failed to clean up collection ${collection}: ${error}`);
+    }
+  }
+}

--- a/packages/plugin-mongo/src/utils.ts
+++ b/packages/plugin-mongo/src/utils.ts
@@ -1,8 +1,8 @@
 import type { ClientSession, MongoClient } from "mongodb";
 
 export class MongoStorageError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = "MongoStorageError";
   }
 }


### PR DESCRIPTION
adds a `--alwaysReindex` flag to `apibara dev` command which resets the database state on every restart of indexers.