### PR TITLE
Export missing network-specific types

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --strict-peer-dependencies=false --no-frozen-lockfile
       - name: Run build
-        run: pnpm build --filter=!./examples/cli --filter=!./examples/cli-js
+        run: pnpm build --filter=!./examples/cli-drizzle --filter=!./examples/cli-instrumentation --filter=!./examples/cli-js
       - name: Set git credentials
         run: |
           git config user.name "Capy Bot"

--- a/change/@apibara-beaconchain-a2f3aecc-d68f-4565-abd5-54ad31d76e13.json
+++ b/change/@apibara-beaconchain-a2f3aecc-d68f-4565-abd5-54ad31d76e13.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "beaconchain: export missing types",
+  "packageName": "@apibara/beaconchain",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-evm-328b69a1-8d4e-47f7-b745-df6e9cfaa69a.json
+++ b/change/@apibara-evm-328b69a1-8d4e-47f7-b745-df6e9cfaa69a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "evm: export missing types",
+  "packageName": "@apibara/evm",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-starknet-f65db5dd-f330-46e6-ad23-b5e9b8fb1939.json
+++ b/change/@apibara-starknet-f65db5dd-f330-46e6-ad23-b5e9b8fb1939.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "starknet: export missing types",
+  "packageName": "@apibara/starknet",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/packages/beaconchain/src/block.ts
+++ b/packages/beaconchain/src/block.ts
@@ -49,6 +49,8 @@ export const Validator = Schema.Struct({
   withdrawableEpoch: Schema.BigIntFromSelf,
 });
 
+export type Validator = typeof Validator.Type;
+
 export const Blob = Schema.Struct({
   filterIds: Schema.Array(Schema.Number),
   blobIndex: Schema.Number,
@@ -60,6 +62,8 @@ export const Blob = Schema.Struct({
   transactionIndex: Schema.Number,
   transactionHash: B256,
 });
+
+export type Blob = typeof Blob.Type;
 
 export const Signature = Schema.Struct({
   r: Schema.optional(U256),

--- a/packages/beaconchain/src/common.ts
+++ b/packages/beaconchain/src/common.ts
@@ -59,6 +59,8 @@ export const ValidatorStatus = Schema.transform(
   },
 );
 
+export type ValidatorStatus = typeof ValidatorStatus.Type;
+
 const _B384 = Schema.TemplateLiteral(Schema.Literal("0x"), Schema.String);
 const B384Proto = Schema.Struct({
   x0: Schema.BigIntFromSelf,

--- a/packages/evm/src/block.ts
+++ b/packages/evm/src/block.ts
@@ -20,6 +20,8 @@ export const Bloom = Schema.transform(
   },
 );
 
+export type Bloom = typeof Bloom.Type;
+
 export const TransactionStatus = Schema.transform(
   Schema.Enums(proto.data.TransactionStatus),
   Schema.Literal("unknown", "succeeded", "reverted"),
@@ -78,10 +80,14 @@ export const Withdrawal = Schema.Struct({
   amount: Schema.BigIntFromSelf,
 });
 
+export type Withdrawal = typeof Withdrawal.Type;
+
 export const AccessListItem = Schema.Struct({
   address: Address,
   storageKeys: Schema.Array(B256),
 });
+
+export type AccessListItem = typeof AccessListItem.Type;
 
 export const Signature = Schema.Struct({
   r: U256,
@@ -89,6 +95,8 @@ export const Signature = Schema.Struct({
   v: U256,
   YParity: Schema.optional(Schema.Boolean),
 });
+
+export type Signature = typeof Signature.Type;
 
 export const Transaction = Schema.Struct({
   filterIds: Schema.Array(Schema.Number),
@@ -112,6 +120,8 @@ export const Transaction = Schema.Struct({
   transactionStatus: TransactionStatus,
 });
 
+export type Transaction = typeof Transaction.Type;
+
 export const TransactionReceipt = Schema.Struct({
   filterIds: Schema.Array(Schema.Number),
   transactionIndex: Schema.Number,
@@ -128,6 +138,8 @@ export const TransactionReceipt = Schema.Struct({
   blobGasPrice: Schema.optional(U128),
   transactionStatus: TransactionStatus,
 });
+
+export type TransactionReceipt = typeof TransactionReceipt.Type;
 
 export const Log = Schema.Struct({
   filterIds: Schema.Array(Schema.Number),

--- a/packages/evm/src/common.ts
+++ b/packages/evm/src/common.ts
@@ -62,6 +62,8 @@ export const B256 = Schema.transform(B256Proto, _B256, {
   },
 });
 
+export type B256 = typeof B256.Type;
+
 export const b256ToProto = Schema.encodeSync(B256);
 export const b256FromProto = Schema.decodeSync(B256);
 
@@ -92,6 +94,8 @@ export const U256 = Schema.transform(U256Proto, Schema.BigIntFromSelf, {
   },
 });
 
+export type U256 = typeof U256.Type;
+
 export const u256ToProto = Schema.encodeSync(U256);
 export const u256FromProto = Schema.decodeSync(U256);
 
@@ -112,6 +116,8 @@ export const U128 = Schema.transform(U128Proto, Schema.BigIntFromSelf, {
     return { x0, x1 };
   },
 });
+
+export type U128 = typeof U128.Type;
 
 export const u128ToProto = Schema.encodeSync(U128);
 export const u128FromProto = Schema.decodeSync(U128);

--- a/packages/evm/src/filter.ts
+++ b/packages/evm/src/filter.ts
@@ -103,6 +103,8 @@ export const Topic = Schema.transform(
   },
 );
 
+export type Topic = typeof Topic.Type;
+
 export const LogFilter = Schema.Struct({
   id: Schema.optional(Schema.Number),
   address: Schema.optional(Address),

--- a/packages/starknet/src/block.ts
+++ b/packages/starknet/src/block.ts
@@ -14,6 +14,8 @@ export const ResourcePrice = Schema.Struct({
   priceInWei: Schema.optional(FieldElement),
 });
 
+export type ResourcePrice = typeof ResourcePrice.Type;
+
 /** How data is posted to L1. */
 export const L1DataAvailabilityMode = Schema.transform(
   Schema.Enums(proto.data.L1DataAvailabilityMode),
@@ -34,6 +36,8 @@ export const L1DataAvailabilityMode = Schema.transform(
     },
   },
 );
+
+export type L1DataAvailabilityMode = typeof L1DataAvailabilityMode.Type;
 
 export const TransactionStatus = Schema.transform(
   Schema.Enums(proto.data.TransactionStatus),
@@ -75,15 +79,21 @@ export const U128 = Schema.transform(
   },
 );
 
+export type U128 = typeof U128.Type;
+
 export const ResourceBounds = Schema.Struct({
   maxAmount: Schema.BigIntFromSelf,
   maxPricePerUnit: U128,
 });
 
+export type ResourceBounds = typeof ResourceBounds.Type;
+
 export const ResourceBoundsMapping = Schema.Struct({
   l1Gas: ResourceBounds,
   l2Gas: ResourceBounds,
 });
+
+export type ResourceBoundsMapping = typeof ResourceBoundsMapping.Type;
 
 export const DataAvailabilityMode = Schema.transform(
   Schema.Enums(proto.data.DataAvailabilityMode),
@@ -104,6 +114,8 @@ export const DataAvailabilityMode = Schema.transform(
     },
   },
 );
+
+export type DataAvailabilityMode = typeof DataAvailabilityMode.Type;
 
 /** Starknet block header.
  *
@@ -160,6 +172,8 @@ export const InvokeTransactionV0 = Schema.Struct({
   }),
 });
 
+export type InvokeTransactionV0 = typeof InvokeTransactionV0.Type;
+
 export const InvokeTransactionV1 = Schema.Struct({
   _tag: tag("invokeV1"),
   invokeV1: Schema.Struct({
@@ -170,6 +184,8 @@ export const InvokeTransactionV1 = Schema.Struct({
     nonce: FieldElement,
   }),
 });
+
+export type InvokeTransactionV1 = typeof InvokeTransactionV1.Type;
 
 export const InvokeTransactionV3 = Schema.Struct({
   _tag: tag("invokeV3"),
@@ -187,6 +203,8 @@ export const InvokeTransactionV3 = Schema.Struct({
   }),
 });
 
+export type InvokeTransactionV3 = typeof InvokeTransactionV3.Type;
+
 export const L1HandlerTransaction = Schema.Struct({
   _tag: tag("l1Handler"),
   l1Handler: Schema.Struct({
@@ -197,6 +215,8 @@ export const L1HandlerTransaction = Schema.Struct({
   }),
 });
 
+export type L1HandlerTransaction = typeof L1HandlerTransaction.Type;
+
 export const DeployTransaction = Schema.Struct({
   _tag: tag("deploy"),
   deploy: Schema.Struct({
@@ -205,6 +225,8 @@ export const DeployTransaction = Schema.Struct({
     classHash: FieldElement,
   }),
 });
+
+export type DeployTransaction = typeof DeployTransaction.Type;
 
 export const DeclareTransactionV0 = Schema.Struct({
   _tag: tag("declareV0"),
@@ -215,6 +237,8 @@ export const DeclareTransactionV0 = Schema.Struct({
     classHash: FieldElement,
   }),
 });
+
+export type DeclareTransactionV0 = typeof DeclareTransactionV0.Type;
 
 export const DeclareTransactionV1 = Schema.Struct({
   _tag: tag("declareV1"),
@@ -227,6 +251,8 @@ export const DeclareTransactionV1 = Schema.Struct({
   }),
 });
 
+export type DeclareTransactionV1 = typeof DeclareTransactionV1.Type;
+
 export const DeclareTransactionV2 = Schema.Struct({
   _tag: tag("declareV2"),
   declareV2: Schema.Struct({
@@ -238,6 +264,8 @@ export const DeclareTransactionV2 = Schema.Struct({
     classHash: FieldElement,
   }),
 });
+
+export type DeclareTransactionV2 = typeof DeclareTransactionV2.Type;
 
 export const DeclareTransactionV3 = Schema.Struct({
   _tag: tag("declareV3"),
@@ -256,6 +284,8 @@ export const DeclareTransactionV3 = Schema.Struct({
   }),
 });
 
+export type DeclareTransactionV3 = typeof DeclareTransactionV3.Type;
+
 export const DeployAccountTransactionV1 = Schema.Struct({
   _tag: tag("deployAccountV1"),
   deployAccountV1: Schema.Struct({
@@ -267,6 +297,8 @@ export const DeployAccountTransactionV1 = Schema.Struct({
     classHash: FieldElement,
   }),
 });
+
+export type DeployAccountTransactionV1 = typeof DeployAccountTransactionV1.Type;
 
 export const DeployAccountTransactionV3 = Schema.Struct({
   _tag: tag("deployAccountV3"),
@@ -283,6 +315,8 @@ export const DeployAccountTransactionV3 = Schema.Struct({
     feeDataAvailabilityMode: DataAvailabilityMode,
   }),
 });
+
+export type DeployAccountTransactionV3 = typeof DeployAccountTransactionV3.Type;
 
 /** A transaction.
  *
@@ -328,10 +362,14 @@ export const PriceUnit = Schema.transform(
   },
 );
 
+export type PriceUnit = typeof PriceUnit.Type;
+
 export const FeePayment = Schema.Struct({
   amount: FieldElement,
   unit: PriceUnit,
 });
+
+export type FeePayment = typeof FeePayment.Type;
 
 export const ComputationResources = Schema.Struct({
   steps: Schema.BigIntFromSelf,
@@ -346,20 +384,28 @@ export const ComputationResources = Schema.Struct({
   segmentArenaBuiltin: Schema.optional(Schema.BigIntFromSelf),
 });
 
+export type ComputationResources = typeof ComputationResources.Type;
+
 export const DataAvailabilityResources = Schema.Struct({
   l1Gas: Schema.BigIntFromSelf,
   l1DataGas: Schema.BigIntFromSelf,
 });
+
+export type DataAvailabilityResources = typeof DataAvailabilityResources.Type;
 
 export const ExecutionResources = Schema.Struct({
   computation: ComputationResources,
   dataAvailability: DataAvailabilityResources,
 });
 
+export type ExecutionResources = typeof ExecutionResources.Type;
+
 export const ExecutionSucceeded = Schema.Struct({
   _tag: tag("succeeded"),
   succeeded: Schema.Struct({}),
 });
+
+export type ExecutionSucceeded = typeof ExecutionSucceeded.Type;
 
 export const ExecutionReverted = Schema.Struct({
   _tag: tag("reverted"),
@@ -367,6 +413,8 @@ export const ExecutionReverted = Schema.Struct({
     reason: Schema.optional(Schema.String),
   }),
 });
+
+export type ExecutionReverted = typeof ExecutionReverted.Type;
 
 /** Common fields for all transaction receipts. */
 export const TransactionReceiptMeta = Schema.Struct({
@@ -377,10 +425,14 @@ export const TransactionReceiptMeta = Schema.Struct({
   executionResult: Schema.Union(ExecutionSucceeded, ExecutionReverted),
 });
 
+export type TransactionReceiptMeta = typeof TransactionReceiptMeta.Type;
+
 export const InvokeTransactionReceipt = Schema.Struct({
   _tag: tag("invoke"),
   invoke: Schema.Struct({}),
 });
+
+export type InvokeTransactionReceipt = typeof InvokeTransactionReceipt.Type;
 
 export const L1HandlerTransactionReceipt = Schema.Struct({
   _tag: tag("l1Handler"),
@@ -389,10 +441,15 @@ export const L1HandlerTransactionReceipt = Schema.Struct({
   }),
 });
 
+export type L1HandlerTransactionReceipt =
+  typeof L1HandlerTransactionReceipt.Type;
+
 export const DeclareTransactionReceipt = Schema.Struct({
   _tag: tag("declare"),
   declare: Schema.Struct({}),
 });
+
+export type DeclareTransactionReceipt = typeof DeclareTransactionReceipt.Type;
 
 export const DeployTransactionReceipt = Schema.Struct({
   _tag: tag("deploy"),
@@ -401,12 +458,17 @@ export const DeployTransactionReceipt = Schema.Struct({
   }),
 });
 
+export type DeployTransactionReceipt = typeof DeployTransactionReceipt.Type;
+
 export const DeployAccountTransactionReceipt = Schema.Struct({
   _tag: tag("deployAccount"),
   deployAccount: Schema.Struct({
     contractAddress: FieldElement,
   }),
 });
+
+export type DeployAccountTransactionReceipt =
+  typeof DeployAccountTransactionReceipt.Type;
 
 /** A transaction receipt.
  *

--- a/packages/starknet/src/filter.ts
+++ b/packages/starknet/src/filter.ts
@@ -147,55 +147,79 @@ export const InvokeTransactionV0Filter = Schema.Struct({
   invokeV0: Schema.Struct({}),
 });
 
+export type InvokeTransactionV0Filter = typeof InvokeTransactionV0Filter.Type;
+
 export const InvokeTransactionV1Filter = Schema.Struct({
   _tag: tag("invokeV1"),
   invokeV1: Schema.Struct({}),
 });
+
+export type InvokeTransactionV1Filter = typeof InvokeTransactionV1Filter.Type;
 
 export const InvokeTransactionV3Filter = Schema.Struct({
   _tag: tag("invokeV3"),
   invokeV3: Schema.Struct({}),
 });
 
+export type InvokeTransactionV3Filter = typeof InvokeTransactionV3Filter.Type;
+
 export const DeployTransactionFilter = Schema.Struct({
   _tag: tag("deploy"),
   deploy: Schema.Struct({}),
 });
+
+export type DeployTransactionFilter = typeof DeployTransactionFilter.Type;
 
 export const DeclareV0TransactionFilter = Schema.Struct({
   _tag: tag("declareV0"),
   declareV0: Schema.Struct({}),
 });
 
+export type DeclareV0TransactionFilter = typeof DeclareV0TransactionFilter.Type;
+
 export const DeclareV1TransactionFilter = Schema.Struct({
   _tag: tag("declareV1"),
   declareV1: Schema.Struct({}),
 });
+
+export type DeclareV1TransactionFilter = typeof DeclareV1TransactionFilter.Type;
 
 export const DeclareV2TransactionFilter = Schema.Struct({
   _tag: tag("declareV2"),
   declareV2: Schema.Struct({}),
 });
 
+export type DeclareV2TransactionFilter = typeof DeclareV2TransactionFilter.Type;
+
 export const DeclareV3TransactionFilter = Schema.Struct({
   _tag: tag("declareV3"),
   declareV3: Schema.Struct({}),
 });
+
+export type DeclareV3TransactionFilter = typeof DeclareV3TransactionFilter.Type;
 
 export const L1HandlerTransactionFilter = Schema.Struct({
   _tag: tag("l1Handler"),
   l1Handler: Schema.Struct({}),
 });
 
+export type L1HandlerTransactionFilter = typeof L1HandlerTransactionFilter.Type;
+
 export const DeployAccountV1TransactionFilter = Schema.Struct({
   _tag: tag("deployAccountV1"),
   deployAccountV1: Schema.Struct({}),
 });
 
+export type DeployAccountV1TransactionFilter =
+  typeof DeployAccountV1TransactionFilter.Type;
+
 export const DeployAccountV3TransactionFilter = Schema.Struct({
   _tag: tag("deployAccountV3"),
   deployAccountV3: Schema.Struct({}),
 });
+
+export type DeployAccountV3TransactionFilter =
+  typeof DeployAccountV3TransactionFilter.Type;
 
 /** Filter transactions.
  *
@@ -275,6 +299,8 @@ export const ContractChangeFilter = Schema.Struct({
   ),
 });
 
+export type ContractChangeFilter = typeof ContractChangeFilter.Type;
+
 /** Filter updates to nonces.
  *
  * @prop contractAddress Filter by contract address.
@@ -283,6 +309,8 @@ export const NonceUpdateFilter = Schema.Struct({
   id: Schema.optional(Schema.Number),
   contractAddress: Schema.optional(FieldElement),
 });
+
+export type NonceUpdateFilter = typeof NonceUpdateFilter.Type;
 
 export const Filter = Schema.Struct({
   header: Schema.optional(HeaderFilter),


### PR DESCRIPTION
Some types were not exported but they are useful when implement indexers.

This PR exports all filter and block types.
