### PR TITLE
plugin-mongo: fix errors on restart and retry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,11 +44,10 @@ jobs:
       - name: Run lint
         run: pnpm lint
       - name: Run build
-        # Exclude examples/cli since it requires the cli to be built.
-        run: pnpm build --filter=!./examples/cli-drizzle --filter=!./examples/cli-instrumentation --filter=!./examples/cli-js
+        run: pnpm build
       - name: Run typecheck
         run: pnpm typecheck
       - name: Run test
-        run: pnpm test:ci --filter=!./examples/cli-drizzle --filter=!./examples/cli-instrumentation --filter=!./examples/cli-js
+        run: pnpm test:ci
       - name: Check change files
         run: pnpm beachball check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --strict-peer-dependencies=false --no-frozen-lockfile
       - name: Run build
-        run: pnpm build --filter=!./examples/cli-drizzle --filter=!./examples/cli-instrumentation --filter=!./examples/cli-js
+        run: pnpm build
       - name: Set git credentials
         run: |
           git config user.name "Capy Bot"

--- a/change/@apibara-plugin-mongo-8a313e7a-5b45-4ae6-9727-2fa720b6f46c.json
+++ b/change/@apibara-plugin-mongo-8a313e7a-5b45-4ae6-9727-2fa720b6f46c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugin-mongo: fix error on connection and disable retry",
+  "packageName": "@apibara/plugin-mongo",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/examples/cli-drizzle/package.json
+++ b/examples/cli-drizzle/package.json
@@ -5,10 +5,7 @@
   "description": "",
   "type": "module",
   "scripts": {
-    "build": "apibara build",
     "dev": "apibara dev",
-    "start": "apibara start",
-    "start:pg": "export POSTGRES_CONNECTION_STRING=\"postgres://postgres:postgres@localhost:5432/postgres\" && pnpm start",
     "lint": "biome check .",
     "lint:fix": "pnpm lint --write",
     "test": "vitest",

--- a/examples/cli-instrumentation/package.json
+++ b/examples/cli-instrumentation/package.json
@@ -5,9 +5,7 @@
   "description": "",
   "type": "module",
   "scripts": {
-    "build": "apibara build",
     "dev": "apibara dev",
-    "start": "apibara start",
     "lint": "biome check .",
     "lint:fix": "pnpm lint --write"
   },

--- a/examples/cli-mongodb/apibara.config.mjs
+++ b/examples/cli-mongodb/apibara.config.mjs
@@ -1,0 +1,3 @@
+import { defineConfig } from "apibara/config";
+
+export default defineConfig({});

--- a/examples/cli-mongodb/docker-compose.yaml
+++ b/examples/cli-mongodb/docker-compose.yaml
@@ -1,0 +1,20 @@
+services:
+  mongo:
+    image: bitnami/mongodb:8.0
+    ports:
+      - 27017:27017
+    environment:
+      MONGODB_PORT_NUMBER: "27017"
+      MONGODB_ROOT_USER: mongo
+      MONGODB_ROOT_PASSWORD: mongo
+      MONGODB_REPLICA_SET_MODE: primary
+      MONGODB_REPLICA_SET_NAME: rs0
+      MONGODB_REPLICA_SET_KEY: mongomongo
+      MONGODB_ADVERTISE_IP: true
+    volumes:
+      - "mongo_data:/data/db"
+      - "mongo_config:/data/configdb"
+
+volumes:
+  mongo_data:
+  mongo_config:

--- a/examples/cli-mongodb/indexers/starknet.indexer.js
+++ b/examples/cli-mongodb/indexers/starknet.indexer.js
@@ -1,0 +1,34 @@
+import { defineIndexer } from "@apibara/indexer";
+import { useLogger } from "@apibara/indexer/plugins";
+import { mongoStorage, useMongoStorage } from "@apibara/plugin-mongo";
+import { StarknetStream } from "@apibara/starknet";
+import { MongoClient } from "mongodb";
+
+export default function (_runtimeConfig) {
+  const mongodb = new MongoClient("mongodb://mongo:mongo@localhost:27017/");
+
+  return defineIndexer(StarknetStream)({
+    streamUrl: "https://starknet.preview.apibara.org",
+    finality: "accepted",
+    startingBlock: 1_000_000n,
+    filter: {
+      transactions: [{}],
+    },
+    plugins: [
+      mongoStorage({
+        client: mongodb,
+        dbName: "test-db",
+        collections: ["blocks", "transactions"],
+      }),
+    ],
+    async transform({ block: { header, transactions } }) {
+      const logger = useLogger();
+      const mongo = useMongoStorage();
+
+      await mongo.collection("blocks").insertOne(header);
+      await mongo.collection("transactions").insertMany(transactions);
+
+      logger.info(`Inserted block ${header.blockNumber}`);
+    },
+  });
+}

--- a/examples/cli-mongodb/package.json
+++ b/examples/cli-mongodb/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "example-cli-js",
+  "name": "example-cli-mongodb",
   "private": true,
   "version": "0.0.0",
   "description": "",
@@ -17,9 +17,10 @@
   },
   "dependencies": {
     "@apibara/indexer": "workspace:*",
+    "@apibara/plugin-mongo": "workspace:*",
     "@apibara/protocol": "workspace:*",
     "@apibara/starknet": "workspace:*",
     "apibara": "workspace:*",
-    "starknet": "^6.11.0"
+    "mongodb": "^6.12.0"
   }
 }

--- a/packages/plugin-mongo/src/persistence.ts
+++ b/packages/plugin-mongo/src/persistence.ts
@@ -22,13 +22,8 @@ export async function initializePersistentState(
   db: Db,
   session: ClientSession,
 ) {
-  const checkpoint = await db.createCollection<CheckpointSchema>(
-    checkpointCollectionName,
-    { session },
-  );
-  const filter = await db.createCollection<FilterSchema>(filterCollectionName, {
-    session,
-  });
+  const checkpoint = db.collection<CheckpointSchema>(checkpointCollectionName);
+  const filter = db.collection<FilterSchema>(filterCollectionName);
 
   await checkpoint.createIndex({ id: 1 }, { session });
   await filter.createIndex({ id: 1, fromBlock: 1 }, { session });

--- a/packages/plugin-mongo/src/utils.ts
+++ b/packages/plugin-mongo/src/utils.ts
@@ -12,8 +12,13 @@ export async function withTransaction<T>(
   cb: (session: ClientSession) => Promise<T>,
 ) {
   return await client.withSession(async (session) => {
-    return await session.withTransaction(async (session) => {
-      return await cb(session);
-    });
+    return await session.withTransaction(
+      async (session) => {
+        return await cb(session);
+      },
+      {
+        retryWrites: false,
+      },
+    );
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,34 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
 
+  examples/cli-mongodb:
+    dependencies:
+      '@apibara/indexer':
+        specifier: workspace:*
+        version: link:../../packages/indexer
+      '@apibara/plugin-mongo':
+        specifier: workspace:*
+        version: link:../../packages/plugin-mongo
+      '@apibara/protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
+      '@apibara/starknet':
+        specifier: workspace:*
+        version: link:../../packages/starknet
+      apibara:
+        specifier: workspace:*
+        version: link:../../packages/cli
+      mongodb:
+        specifier: ^6.12.0
+        version: 6.12.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.5.2
+        version: 20.14.0
+      typescript:
+        specifier: ^5.6.2
+        version: 5.6.2
+
   examples/evm-client:
     dependencies:
       '@apibara/evm':


### PR DESCRIPTION
The MongoDB had the following issues:

 - calling `createCollection` on an already existing collection returns an error.
 - `withTransaction` defaults to retrying by invoking the callback multiple times, but this is unacceptable for the middleware.

This PR fixes both issues.
