### PR TITLE
feat: qol improvements & fixes

### DIFF
--- a/change/@apibara-plugin-drizzle-fb22b1bc-f1ab-4299-a476-2ac25460956d.json
+++ b/change/@apibara-plugin-drizzle-fb22b1bc-f1ab-4299-a476-2ac25460956d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugin-drizzle: add idColumn map support with validation and fix cleanup errors",
+  "packageName": "@apibara/plugin-drizzle",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-plugin-mongo-c9018c01-2b4f-4a5a-a7a7-e13eb567d66f.json
+++ b/change/@apibara-plugin-mongo-c9018c01-2b4f-4a5a-a7a7-e13eb567d66f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugin-mongo: move cleanup part after initialization",
+  "packageName": "@apibara/plugin-mongo",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-plugin-sqlite-22633833-27a0-4ae1-be3b-824b3514f5e2.json
+++ b/change/@apibara-plugin-sqlite-22633833-27a0-4ae1-be3b-824b3514f5e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add cleanup logic and add indexerId relation to KV Store",
+  "packageName": "@apibara/plugin-sqlite",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/apibara-34f7f808-dcf6-45ec-bbe4-5e74b0193361.json
+++ b/change/apibara-34f7f808-dcf6-45ec-bbe4-5e74b0193361.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "cli: fix dev reload, change flag names, args validation, bump drizzle-orm version in template",
+  "packageName": "apibara",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/examples/cli-drizzle/indexers/2-starknet.indexer.ts
+++ b/examples/cli-drizzle/indexers/2-starknet.indexer.ts
@@ -28,7 +28,9 @@ export default function (runtimeConfig: ApibaraRuntimeConfig) {
     plugins: [
       drizzleStorage({
         db: database,
-        idColumn: "_id",
+        idColumn: {
+          "*": "_id",
+        },
         persistState: true,
         indexerName: "starknet-usdc-transfers",
         migrate: {

--- a/examples/cli-drizzle/package.json
+++ b/examples/cli-drizzle/package.json
@@ -31,7 +31,7 @@
     "@apibara/starknet": "workspace:*",
     "@electric-sql/pglite": "^0.2.17",
     "apibara": "workspace:*",
-    "drizzle-orm": "^0.37.0",
+    "drizzle-orm": "^0.40.1",
     "pg": "^8.13.1",
     "starknet": "^6.11.0",
     "viem": "^2.21.53"

--- a/packages/cli/src/cli/commands/add.ts
+++ b/packages/cli/src/cli/commands/add.ts
@@ -1,5 +1,6 @@
 import { addIndexer } from "apibara/create";
 import { defineCommand } from "citty";
+import { checkForUnknownArgs } from "../common";
 
 export default defineCommand({
   meta: {
@@ -35,7 +36,9 @@ export default defineCommand({
         "Root directory - apibara project root where apibara.config is located | default: current working directory",
     },
   },
-  async run({ args }) {
+  async run({ args, cmd }) {
+    await checkForUnknownArgs(args, cmd);
+
     const { indexerId, chain, network, storage, dnaUrl, dir } = args;
 
     await addIndexer({

--- a/packages/cli/src/cli/commands/build.ts
+++ b/packages/cli/src/cli/commands/build.ts
@@ -2,7 +2,7 @@ import { build, createApibara, prepare, writeTypes } from "apibara/core";
 import { runtimeDir } from "apibara/runtime/meta";
 import { defineCommand } from "citty";
 import { join, resolve } from "pathe";
-import { commonArgs } from "../common";
+import { checkForUnknownArgs, commonArgs } from "../common";
 
 export default defineCommand({
   meta: {
@@ -12,8 +12,11 @@ export default defineCommand({
   args: {
     ...commonArgs,
   },
-  async run({ args }) {
+  async run({ args, cmd }) {
+    await checkForUnknownArgs(args, cmd);
+
     const rootDir = resolve((args.dir || args._dir || ".") as string);
+
     const apibara = await createApibara({
       rootDir,
     });

--- a/packages/cli/src/cli/commands/dev.ts
+++ b/packages/cli/src/cli/commands/dev.ts
@@ -125,7 +125,6 @@ export default defineCommand({
               code !== null ? ` with code ${colors.red(code)}` : ""
             }`,
           );
-          process.exit(code ?? 0);
         });
       });
     };

--- a/packages/cli/src/cli/commands/dev.ts
+++ b/packages/cli/src/cli/commands/dev.ts
@@ -5,7 +5,7 @@ import type { Apibara } from "apibara/types";
 import { defineCommand } from "citty";
 import { colors } from "consola/utils";
 import { join, resolve } from "pathe";
-import { commonArgs } from "../common";
+import { checkForUnknownArgs, commonArgs } from "../common";
 
 // Hot module reloading key regex
 // for only runtimeConfig.* keys
@@ -26,17 +26,19 @@ export default defineCommand({
       type: "string",
       description: "Preset to use",
     },
-    alwaysReindex: {
+    "always-reindex": {
       type: "boolean",
       default: false,
       description:
-        "Reindex the indexers from the starting block on every restart (default: false)",
+        "Reindex the indexers from the starting block on every restart | default: `false`",
     },
   },
-  async run({ args }) {
+  async run({ args, data, cmd, rawArgs }) {
+    await checkForUnknownArgs(args, cmd);
+
     const rootDir = resolve((args.dir || args._dir || ".") as string);
 
-    if (args.alwaysReindex) {
+    if (args["always-reindex"]) {
       process.env.APIBARA_ALWAYS_REINDEX = "true";
     }
 

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -1,5 +1,6 @@
 import { initializeProject } from "apibara/create";
 import { defineCommand } from "citty";
+import { checkForUnknownArgs } from "../common";
 
 export default defineCommand({
   meta: {
@@ -14,23 +15,27 @@ export default defineCommand({
     },
     language: {
       type: "string",
-      description: "Language to use: typescript, ts or javascript, js",
+      description:
+        "Language to use: typescript, ts or javascript, js | default: `ts`",
       default: "ts",
       alias: "l",
     },
-    noIndexer: {
+    "create-indexer": {
       type: "boolean",
-      description: "Do not create an indexer after initialization",
-      default: false,
+      name: "create-indexer",
+      default: true,
+      description: "TODO",
     },
   },
-  async run({ args }) {
-    const { dir: targetDir, noIndexer, language } = args;
+  async run({ args, cmd }) {
+    await checkForUnknownArgs(args, cmd);
+
+    const { dir: targetDir, "create-indexer": createIndexer, language } = args;
 
     await initializeProject({
       argTargetDir: targetDir,
       argLanguage: language,
-      argNoCreateIndexer: noIndexer,
+      argNoCreateIndexer: !createIndexer,
     });
   },
 });

--- a/packages/cli/src/cli/commands/prepare.ts
+++ b/packages/cli/src/cli/commands/prepare.ts
@@ -2,7 +2,7 @@ import { createApibara, writeTypes } from "apibara/core";
 import {} from "apibara/types";
 import { defineCommand } from "citty";
 import { resolve } from "pathe";
-import { commonArgs } from "../common";
+import { checkForUnknownArgs, commonArgs } from "../common";
 
 export default defineCommand({
   meta: {
@@ -12,7 +12,9 @@ export default defineCommand({
   args: {
     ...commonArgs,
   },
-  async run({ args }) {
+  async run({ args, cmd }) {
+    await checkForUnknownArgs(args, cmd);
+
     const rootDir = resolve((args.dir || ".") as string);
     const apibara = await createApibara({ rootDir });
     await writeTypes(apibara);

--- a/packages/cli/src/cli/commands/start.ts
+++ b/packages/cli/src/cli/commands/start.ts
@@ -67,7 +67,6 @@ export default defineCommand({
           code !== null ? ` with code ${colors.red(code)}` : ""
         }`,
       );
-      process.exit(code ?? 0);
     });
   },
 });

--- a/packages/cli/src/cli/commands/start.ts
+++ b/packages/cli/src/cli/commands/start.ts
@@ -4,7 +4,7 @@ import { defineCommand } from "citty";
 import { colors } from "consola/utils";
 import fse from "fs-extra";
 import { resolve } from "pathe";
-import { commonArgs } from "../common";
+import { checkForUnknownArgs, commonArgs } from "../common";
 
 export default defineCommand({
   meta: {
@@ -23,9 +23,11 @@ export default defineCommand({
       description: "The preset to use",
     },
   },
-  async run({ args }) {
+  async run({ args, cmd }) {
     const { indexer, preset } = args;
     const rootDir = resolve((args.dir || args._dir || ".") as string);
+
+    await checkForUnknownArgs(args, cmd);
 
     const apibara = await createApibara({
       rootDir,

--- a/packages/cli/src/cli/common.ts
+++ b/packages/cli/src/cli/common.ts
@@ -17,7 +17,18 @@ export const checkForUnknownArgs = async <T extends ArgsDef = ArgsDef>(
   args: ParsedArgs<T>,
   cmd: CommandDef<T>,
 ) => {
-  const definedArgs = Object.keys(cmd.args ?? {});
+  // Create a list of defined args including both the main arg names and their aliases
+  const definedArgs: string[] = [];
+  if (cmd.args) {
+    for (const [argName, argDef] of Object.entries(cmd.args)) {
+      definedArgs.push(argName);
+      // Add alias to definedArgs if it exists
+      if (argDef.alias) {
+        definedArgs.push(argDef.alias);
+      }
+    }
+  }
+
   const providedArgs = Object.keys(args).filter((arg) => arg !== "_");
   const wrongArgs = providedArgs.filter((arg) => !definedArgs.includes(arg));
 

--- a/packages/cli/src/cli/common.ts
+++ b/packages/cli/src/cli/common.ts
@@ -1,8 +1,29 @@
-import type { ArgsDef } from "citty";
+import {
+  type ArgsDef,
+  type CommandDef,
+  type ParsedArgs,
+  renderUsage,
+} from "citty";
+import consola from "consola";
 
 export const commonArgs = <ArgsDef>{
   dir: {
     type: "string",
     description: "project root directory",
   },
+};
+
+export const checkForUnknownArgs = async <T extends ArgsDef = ArgsDef>(
+  args: ParsedArgs<T>,
+  cmd: CommandDef<T>,
+) => {
+  const definedArgs = Object.keys(cmd.args ?? {});
+  const providedArgs = Object.keys(args).filter((arg) => arg !== "_");
+  const wrongArgs = providedArgs.filter((arg) => !definedArgs.includes(arg));
+
+  if (wrongArgs.length > 0) {
+    consola.error(`Unknown arguments: ${wrongArgs.join(", ")}`);
+    consola.info(await renderUsage(cmd));
+    process.exit(1);
+  }
 };

--- a/packages/cli/src/create/constants.ts
+++ b/packages/cli/src/create/constants.ts
@@ -79,7 +79,7 @@ export const packageVersions = {
   "@apibara/plugin-sqlite": "next",
   // Postgres Dependencies
   "@electric-sql/pglite": "^0.2.17",
-  "drizzle-orm": "^0.37.0",
+  "drizzle-orm": "^0.40.1",
   pg: "^8.13.1",
   "@types/pg": "^8.11.10",
   "drizzle-kit": "^0.29.0",

--- a/packages/plugin-drizzle/src/index.ts
+++ b/packages/plugin-drizzle/src/index.ts
@@ -186,7 +186,7 @@ export function drizzleStorage<
       if (!columnExists) {
         throw new DrizzleStorageError(
           `Column \`"${tableIdColumn}"\` does not exist in table \`"${table.dbName}"\`. ` +
-            "Make sure the table has the specified column or provide a valid `idColumn` mapping in the options of `drizzleStorage`.",
+            "Make sure the table has the specified column or provide a valid `idColumn` mapping to `drizzleStorage`.",
         );
       }
     }

--- a/packages/plugin-drizzle/src/utils.ts
+++ b/packages/plugin-drizzle/src/utils.ts
@@ -48,3 +48,22 @@ export function serialize<T>(obj: T): string {
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+export interface IdColumnMap extends Record<string, string> {
+  /**
+   * Wildcard mapping for all tables.
+   */
+  "*": string;
+}
+
+export const getIdColumnForTable = (
+  tableName: string,
+  idColumn: IdColumnMap,
+): string => {
+  // If there's a specific mapping for this table, use it
+  if (idColumn[tableName]) {
+    return idColumn[tableName];
+  }
+  // Default fallback
+  return idColumn["*"];
+};

--- a/packages/plugin-sqlite/src/kv.ts
+++ b/packages/plugin-sqlite/src/kv.ts
@@ -19,57 +19,72 @@ export class KeyValueStore {
     private readonly finality: DataFinality,
     private readonly serialize: SerializeFn,
     private readonly deserialize: DeserializeFn,
+    private readonly indexerId: string,
   ) {
     assertInTransaction(db);
   }
 
   get<T>(key: string): T | undefined {
-    const row = this.db.prepare<string, KeyValueRow>(statements.get).get(key);
+    const row = this.db
+      .prepare<[string, string], KeyValueRow>(statements.get)
+      .get(key, this.indexerId);
 
     return row ? this.deserialize(row.v) : undefined;
   }
 
   put<T>(key: string, value: T) {
     this.db
-      .prepare<[number, string], KeyValueRow>(statements.updateToBlock)
-      .run(Number(this.endCursor.orderKey), key);
+      .prepare<[number, string, string], KeyValueRow>(statements.updateToBlock)
+      .run(Number(this.endCursor.orderKey), key, this.indexerId);
 
     this.db
-      .prepare<[number, string, string], KeyValueRow>(statements.insertIntoKvs)
+      .prepare<[number, string, string, string], KeyValueRow>(
+        statements.insertIntoKvs,
+      )
       .run(
         Number(this.endCursor.orderKey),
         key,
         this.serialize(value as Record<string, unknown>),
+        this.indexerId,
       );
   }
 
   del(key: string) {
     this.db
-      .prepare<[number, string], KeyValueRow>(statements.del)
-      .run(Number(this.endCursor.orderKey), key);
+      .prepare<[number, string, string], KeyValueRow>(statements.del)
+      .run(Number(this.endCursor.orderKey), key, this.indexerId);
   }
 }
 
-export function finalizeKV(db: Database, cursor: Cursor) {
+export function finalizeKV(db: Database, cursor: Cursor, indexerId: string) {
   assertInTransaction(db);
 
-  db.prepare<[number], KeyValueRow>(statements.finalize).run(
+  db.prepare<[number, string], KeyValueRow>(statements.finalize).run(
     Number(cursor.orderKey),
+    indexerId,
   );
 }
 
-export function invalidateKV(db: Database, cursor: Cursor) {
+export function invalidateKV(db: Database, cursor: Cursor, indexerId: string) {
   assertInTransaction(db);
 
   // Delete entries that started after the invalidation cursor
-  db.prepare<[number], KeyValueRow>(statements.invalidateDelete).run(
+  db.prepare<[number, string], KeyValueRow>(statements.invalidateDelete).run(
     Number(cursor.orderKey),
+    indexerId,
   );
 
   // Update entries that were supposed to end after the invalidation cursor
-  db.prepare<[number], KeyValueRow>(statements.invalidateUpdate).run(
+  db.prepare<[number, string], KeyValueRow>(statements.invalidateUpdate).run(
     Number(cursor.orderKey),
+    indexerId,
   );
+}
+
+export function cleanupKV(db: Database, indexerId: string) {
+  assertInTransaction(db);
+
+  db.prepare<[string], KeyValueRow>(statements.cleanup).run(indexerId);
 }
 
 export type KeyValueRow = {
@@ -77,6 +92,7 @@ export type KeyValueRow = {
   to_block: number;
   k: string;
   v: string;
+  id: string;
 };
 
 const statements = {
@@ -86,31 +102,35 @@ const statements = {
       to_block INTEGER,
       k TEXT NOT NULL,
       v BLOB NOT NULL,
-      PRIMARY KEY (from_block, k)
+      id TEXT NOT NULL,
+      PRIMARY KEY (from_block, k, id)
       );`,
   get: `
     SELECT v
     FROM kvs
-    WHERE k = ? AND to_block IS NULL`,
+    WHERE k = ? AND id = ? AND to_block IS NULL`,
   updateToBlock: `
     UPDATE kvs
     SET to_block = ?
-    WHERE k = ? AND to_block IS NULL`,
+    WHERE k = ? AND id = ? AND to_block IS NULL`,
   insertIntoKvs: `
-    INSERT INTO kvs (from_block, to_block, k, v)
-    VALUES (?, NULL, ?, ?)`,
+    INSERT INTO kvs (from_block, to_block, k, v, id)
+    VALUES (?, NULL, ?, ?, ?)`,
   del: `
     UPDATE kvs
     SET to_block = ?
-    WHERE k = ? AND to_block IS NULL`,
+    WHERE k = ? AND id = ? AND to_block IS NULL`,
   finalize: `
     DELETE FROM kvs
-    WHERE to_block <= ?`,
+    WHERE to_block <= ? AND id = ?`,
   invalidateDelete: `
     DELETE FROM kvs
-    WHERE from_block > ?`,
+    WHERE from_block > ? AND id = ?`,
   invalidateUpdate: `
     UPDATE kvs
     SET to_block = NULL
-    WHERE to_block > ?`,
-};
+    WHERE to_block > ? AND id = ?`,
+  cleanup: `
+    DELETE FROM kvs
+    WHERE id = ?`,
+} as const;

--- a/packages/plugin-sqlite/src/persistence.ts
+++ b/packages/plugin-sqlite/src/persistence.ts
@@ -100,6 +100,16 @@ export function invalidateState(props: {
   );
 }
 
+export function resetPersistence(props: {
+  db: Database;
+  indexerId: string;
+}) {
+  const { db, indexerId } = props;
+  assertInTransaction(db);
+  db.prepare<[string]>(statements.resetCheckpoint).run(indexerId);
+  db.prepare<[string]>(statements.resetFilter).run(indexerId);
+}
+
 export type CheckpointRow = {
   id: string;
   order_key: number;
@@ -168,4 +178,10 @@ const statements = {
     UPDATE filters
     SET to_block = NULL
     WHERE id = ? AND to_block > ?`,
+  resetCheckpoint: `
+    DELETE FROM checkpoints
+    WHERE id = ?`,
+  resetFilter: `
+    DELETE FROM filters
+    WHERE id = ?`,
 };

--- a/packages/plugin-sqlite/tests/kv.test.ts
+++ b/packages/plugin-sqlite/tests/kv.test.ts
@@ -52,36 +52,42 @@ describe("SQLite key-value store", () => {
       [
         {
           "from_block": 5000000,
+          "id": "indexer_testing_default",
           "k": "data-5000000",
           "to_block": 5000001,
           "v": ""5000000"",
         },
         {
           "from_block": 5000000,
+          "id": "indexer_testing_default",
           "k": "latest",
           "to_block": 5000001,
           "v": "5000000",
         },
         {
           "from_block": 5000001,
+          "id": "indexer_testing_default",
           "k": "data-5000001",
           "to_block": 5000002,
           "v": ""5000001"",
         },
         {
           "from_block": 5000001,
+          "id": "indexer_testing_default",
           "k": "latest",
           "to_block": 5000002,
           "v": "5000001",
         },
         {
           "from_block": 5000002,
+          "id": "indexer_testing_default",
           "k": "data-5000002",
           "to_block": null,
           "v": ""5000002"",
         },
         {
           "from_block": 5000002,
+          "id": "indexer_testing_default",
           "k": "latest",
           "to_block": null,
           "v": "5000002",
@@ -267,18 +273,21 @@ describe("SQLite key-value store", () => {
       [
         {
           "from_block": 103,
+          "id": "indexer_testing_default",
           "k": "data-103B",
           "to_block": null,
           "v": ""103B"",
         },
         {
           "from_block": 104,
+          "id": "indexer_testing_default",
           "k": "data-104B",
           "to_block": null,
           "v": ""104B"",
         },
         {
           "from_block": 105,
+          "id": "indexer_testing_default",
           "k": "data-105B",
           "to_block": null,
           "v": ""105B"",
@@ -449,24 +458,28 @@ describe("SQLite key-value store", () => {
       [
         {
           "from_block": 103,
+          "id": "indexer_testing_default",
           "k": "data-103",
           "to_block": null,
           "v": ""103B"",
         },
         {
           "from_block": 104,
+          "id": "indexer_testing_default",
           "k": "data-104",
           "to_block": null,
           "v": ""104B"",
         },
         {
           "from_block": 106,
+          "id": "indexer_testing_default",
           "k": "data-106",
           "to_block": null,
           "v": ""106BC"",
         },
         {
           "from_block": 107,
+          "id": "indexer_testing_default",
           "k": "data-107",
           "to_block": null,
           "v": ""107BC"",
@@ -550,12 +563,14 @@ describe("SQLite key-value store", () => {
       [
         {
           "from_block": 5000001,
+          "id": "indexer_testing_default",
           "k": "block-5000001",
           "to_block": null,
           "v": ""accepted-block1"",
         },
         {
           "from_block": 5000002,
+          "id": "indexer_testing_default",
           "k": "block-5000002",
           "to_block": null,
           "v": ""pending-block2"",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/cli
       drizzle-orm:
-        specifier: ^0.37.0
-        version: 0.37.0(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.11)(@types/pg@8.11.10)(better-sqlite3@11.5.0)(pg@8.13.1)(postgres@3.4.4)
+        specifier: ^0.40.1
+        version: 0.40.1(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.11)(@types/pg@8.11.10)(better-sqlite3@11.5.0)(pg@8.13.1)(postgres@3.4.4)
       pg:
         specifier: ^8.13.1
         version: 8.13.1
@@ -2839,98 +2839,6 @@ packages:
   drizzle-kit@0.29.1:
     resolution: {integrity: sha512-OvHL8RVyYiPR3LLRE3SHdcON8xGXl+qMfR9uTTnFWBPIqVk/3NWYZPb7nfpM1Bhix3H+BsxqPyyagG7YZ+Z63A==}
     hasBin: true
-
-  drizzle-orm@0.37.0:
-    resolution: {integrity: sha512-AsCNACQ/T2CyZUkrBRUqFT2ibHJ9ZHz3+lzYJFFn3hnj7ylIeItMz5kacRG89uSE74nXYShqehr6u+6ks4JR1A==}
-    peerDependencies:
-      '@aws-sdk/client-rds-data': '>=3'
-      '@cloudflare/workers-types': '>=4'
-      '@electric-sql/pglite': '>=0.2.0'
-      '@libsql/client': '>=0.10.0'
-      '@libsql/client-wasm': '>=0.10.0'
-      '@neondatabase/serverless': '>=0.10.0'
-      '@op-engineering/op-sqlite': '>=2'
-      '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1'
-      '@prisma/client': '*'
-      '@tidbcloud/serverless': '*'
-      '@types/better-sqlite3': '*'
-      '@types/pg': '*'
-      '@types/react': '>=18'
-      '@types/sql.js': '*'
-      '@vercel/postgres': '>=0.8.0'
-      '@xata.io/client': '*'
-      better-sqlite3: '>=7'
-      bun-types: '*'
-      expo-sqlite: '>=14.0.0'
-      knex: '*'
-      kysely: '*'
-      mysql2: '>=2'
-      pg: '>=8'
-      postgres: '>=3'
-      prisma: '*'
-      react: '>=18'
-      sql.js: '>=1'
-      sqlite3: '>=5'
-    peerDependenciesMeta:
-      '@aws-sdk/client-rds-data':
-        optional: true
-      '@cloudflare/workers-types':
-        optional: true
-      '@electric-sql/pglite':
-        optional: true
-      '@libsql/client':
-        optional: true
-      '@libsql/client-wasm':
-        optional: true
-      '@neondatabase/serverless':
-        optional: true
-      '@op-engineering/op-sqlite':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@planetscale/database':
-        optional: true
-      '@prisma/client':
-        optional: true
-      '@tidbcloud/serverless':
-        optional: true
-      '@types/better-sqlite3':
-        optional: true
-      '@types/pg':
-        optional: true
-      '@types/react':
-        optional: true
-      '@types/sql.js':
-        optional: true
-      '@vercel/postgres':
-        optional: true
-      '@xata.io/client':
-        optional: true
-      better-sqlite3:
-        optional: true
-      bun-types:
-        optional: true
-      expo-sqlite:
-        optional: true
-      knex:
-        optional: true
-      kysely:
-        optional: true
-      mysql2:
-        optional: true
-      pg:
-        optional: true
-      postgres:
-        optional: true
-      prisma:
-        optional: true
-      react:
-        optional: true
-      sql.js:
-        optional: true
-      sqlite3:
-        optional: true
 
   drizzle-orm@0.40.1:
     resolution: {integrity: sha512-aPNhtiJiPfm3qxz1czrnIDkfvkSdKGXYeZkpG55NPTVI186LmK2fBLMi4dsHpPHlJrZeQ92D322YFPHADBALew==}
@@ -6849,16 +6757,6 @@ snapshots:
       esbuild-register: 3.6.0(esbuild@0.19.11)
     transitivePeerDependencies:
       - supports-color
-
-  drizzle-orm@0.37.0(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.11)(@types/pg@8.11.10)(better-sqlite3@11.5.0)(pg@8.13.1)(postgres@3.4.4):
-    optionalDependencies:
-      '@electric-sql/pglite': 0.2.17
-      '@opentelemetry/api': 1.9.0
-      '@types/better-sqlite3': 7.6.11
-      '@types/pg': 8.11.10
-      better-sqlite3: 11.5.0
-      pg: 8.13.1
-      postgres: 3.4.4
 
   drizzle-orm@0.40.1(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.11)(@types/pg@8.11.10)(better-sqlite3@11.5.0)(pg@8.13.1)(postgres@3.4.4):
     optionalDependencies:


### PR DESCRIPTION
- Fixes main process exiting on dev reloads
- Changes flag names on cli args
- Adds a validation for unknown args passed in cli, now throws error and prints help message.
- Bumps `drizzle-orm` version in template
- Fix cleanup query errors before initialization when `--always-reindex` flag is set
- Adds `indexerId` relation to KV Store
- Adds `idColumn` map support for table specific id column with wildcard support.
- Adds validation to check if all tables in schema has provided idColumns.