### PR TITLE
Detect postgres connection string

### DIFF
--- a/change/@apibara-plugin-drizzle-558402ff-418e-4c46-a661-863aafb32f4b.json
+++ b/change/@apibara-plugin-drizzle-558402ff-418e-4c46-a661-863aafb32f4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugin-drizzle: detect more postgres connection strings",
+  "packageName": "@apibara/plugin-drizzle",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/packages/plugin-drizzle/src/helper.ts
+++ b/packages/plugin-drizzle/src/helper.ts
@@ -129,7 +129,10 @@ export function drizzle<
     poolConfig,
   } = options ?? {};
 
-  if (connectionString.startsWith("postgres://") || type === "node-postgres") {
+  if (
+    isPostgresConnectionString(connectionString) ||
+    type === "node-postgres"
+  ) {
     const pool = new pg.Pool({
       connectionString,
       ...(poolConfig || {}),
@@ -192,4 +195,8 @@ export async function migrate<TSchema extends Record<string, unknown>>(
       },
     );
   }
+}
+
+function isPostgresConnectionString(conn: string) {
+  return conn.startsWith("postgres://") || conn.startsWith("postgresql://");
 }


### PR DESCRIPTION
Apparently `postgresql://` is also valid.
