### PR TITLE
starknet: add enum event decoder

### DIFF
--- a/change/@apibara-starknet-51bd3f88-6e7d-44b4-958e-febab812fe9a.json
+++ b/change/@apibara-starknet-51bd3f88-6e7d-44b4-958e-febab812fe9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "starknet: add enum event decoding",
+  "packageName": "@apibara/starknet",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/starknet/package.json
+++ b/packages/starknet/package.json
@@ -27,8 +27,8 @@
     "build": "pnpm build:proto && unbuild",
     "build:proto": "buf generate proto",
     "typecheck": "tsc --noEmit",
-    "test": "vitest",
-    "test:ci": "vitest run",
+    "test": "vitest --typecheck",
+    "test:ci": "vitest run --typecheck",
     "lint": "biome check .",
     "lint:fix": "pnpm lint --write",
     "format": "biome format . --write"

--- a/packages/starknet/src/abi-wan-helpers.ts
+++ b/packages/starknet/src/abi-wan-helpers.ts
@@ -1,0 +1,126 @@
+import type { Abi } from "abi-wan-kanabi";
+import type {
+  AbiEventMember,
+  ExtractAbiEvent,
+  ExtractAbiEventNames,
+  StringToPrimitiveType,
+} from "abi-wan-kanabi/kanabi";
+
+export type AbiEventStruct = {
+  type: "event";
+  name: string;
+  kind: "struct";
+  members: AbiEventMember[];
+};
+
+export type AbiMember = {
+  name: string;
+  type: string;
+};
+
+export type AbiEventEnum = {
+  type: "event";
+  name: string;
+  kind: "enum";
+  variants: AbiEventMember[];
+};
+
+export type AbiEvent = AbiEventStruct | AbiEventEnum;
+
+export type AbiItem = Abi[number];
+
+export type DecodeEventArgs<
+  TAbi extends Abi = Abi,
+  TEventName extends ExtractAbiEventNames<TAbi> = ExtractAbiEventNames<TAbi>,
+  TStrict extends boolean = true,
+> = {
+  abi: TAbi;
+  eventName: TEventName;
+  event: Event;
+  strict?: TStrict;
+};
+
+export type DecodedEvent<
+  TAbi extends Abi = Abi,
+  TEventName extends ExtractAbiEventNames<TAbi> = ExtractAbiEventNames<TAbi>,
+> = Event & {
+  eventName: TEventName;
+  args: EventToPrimitiveType<TAbi, TEventName>;
+};
+
+export type DecodeEventReturn<
+  TAbi extends Abi = Abi,
+  TEventName extends ExtractAbiEventNames<TAbi> = ExtractAbiEventNames<TAbi>,
+  TStrict extends boolean = true,
+> = TStrict extends true
+  ? DecodedEvent<TAbi, TEventName>
+  : DecodedEvent<TAbi, TEventName> | null;
+
+// Helper type to resolve the payload type of a nested variant.
+// when the type name corresponds to an event; resolves it using EventToPrimitiveType,
+export type ResolveNestedVariantType<
+  TAbi extends Abi,
+  TTypeName extends string,
+> = EventToPrimitiveType<TAbi, TTypeName>; // resolve its structure recursively
+
+// Helper type to convert a variant member (nested or flat) into its corresponding tagged union part(s).
+export type VariantToTaggedUnion<
+  TAbi extends Abi,
+  TVariant extends AbiEventMember,
+> = TVariant extends { kind: "nested" }
+  ? // Nested: Use the helper to resolve the payload type.
+    { _tag: TVariant["name"] } & {
+      [K in TVariant["name"]]: ResolveNestedVariantType<TAbi, TVariant["type"]>;
+    }
+  : TVariant extends { kind: "flat" }
+    ? // Flat: Recursively call EventToPrimitiveType on the referenced event type.
+      // This will return the union of tagged types for the nested event.
+      EventToPrimitiveType<TAbi, TVariant["type"]>
+    : never; // Should not happen for valid ABIs
+
+// Main type to convert an event definition (struct or enum) to its TS representation.
+export type EventToPrimitiveType<
+  TAbi extends Abi,
+  TEventName extends ExtractAbiEventNames<TAbi>,
+> = ExtractAbiEvent<TAbi, TEventName> extends infer TEventDef
+  ? TEventDef extends {
+      type: "event";
+      kind: "struct";
+      members: infer TMembers extends readonly AbiEventMember[];
+    }
+    ? // Struct Event: A simple object with member names as keys and their primitive types as values.
+      {
+        [Member in TMembers[number] as Member["name"]]: StringToPrimitiveType<
+          TAbi,
+          Member["type"]
+        >;
+      }
+    : TEventDef extends {
+          type: "event";
+          kind: "enum";
+          variants: infer TVariants extends readonly AbiEventMember[];
+        }
+      ? // Enum Event: Create a union of all possible tagged types derived from its variants.
+        {
+          // Map each variant to its corresponding tagged union structure(s).
+          [Idx in keyof TVariants]: VariantToTaggedUnion<TAbi, TVariants[Idx]>;
+        }[number] // Indexing with [number] converts the tuple of union parts into a single union type.
+      : // Explicitly handle empty enum events to ensure the `extends never` check works reliably.
+        TEventDef extends { type: "event"; kind: "enum"; variants: [] }
+        ? never
+        : // Not an event definition found for TEventName -> never
+          never
+  : // If the event name is not found in the ABI, return never.
+    never;
+
+export function isEventAbi(item: AbiItem): item is AbiEvent {
+  return item.type === "event";
+}
+
+export function isStructEventAbi(item: AbiItem): item is AbiEventStruct {
+  return isEventAbi(item) && item.kind === "struct";
+}
+
+export function isEnumEventAbi(item: AbiItem): item is AbiEventEnum {
+  return isEventAbi(item) && item.kind === "enum";
+}

--- a/packages/starknet/src/abi-wan-helpers.ts
+++ b/packages/starknet/src/abi-wan-helpers.ts
@@ -1,3 +1,17 @@
+/*
+
+This file extends "abi-wan-kanabi" to provide a more type-safe way to decode events.
+
+https://github.com/keep-starknet-strange/abi-wan-kanabi
+
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+For more information, please refer to https://unlicense.org
+
+*/
+
 import type { Abi } from "abi-wan-kanabi";
 import type {
   AbiEventMember,

--- a/packages/starknet/src/event.ts
+++ b/packages/starknet/src/event.ts
@@ -1,7 +1,6 @@
 import type { Abi } from "abi-wan-kanabi";
 import type {
   AbiEventMember,
-  EventToPrimitiveType,
   ExtractAbiEventNames,
 } from "abi-wan-kanabi/kanabi";
 import {
@@ -16,6 +15,16 @@ import {
   isPrimitiveType,
   isSpanType,
 } from "./abi";
+import {
+  type AbiEvent,
+  type AbiEventEnum,
+  type AbiEventStruct,
+  type AbiMember,
+  type EventToPrimitiveType,
+  isEnumEventAbi,
+  isEventAbi,
+  isStructEventAbi,
+} from "./abi-wan-helpers";
 import type { Event } from "./block";
 import {
   ParseError,
@@ -78,61 +87,178 @@ export function decodeEvent<
     (item) => item.name === eventName && item.type === "event",
   );
 
-  if (!eventAbi || eventAbi.type !== "event") {
+  if (!eventAbi || !isEventAbi(eventAbi)) {
     if (strict) {
       throw new DecodeEventError(`Event ${eventName} not found in ABI`);
     }
-
     return null as DecodeEventReturn<TAbi, TEventName, TStrict>;
   }
-
-  if (eventAbi.kind === "enum") {
-    throw new DecodeEventError("enum: not implemented");
-  }
-
-  const selector = BigInt(getEventSelector(eventName));
-  if ((event.keys && selector !== BigInt(event.keys[0])) || !event.keys) {
-    if (strict) {
-      throw new DecodeEventError(
-        `Selector mismatch. Expected ${selector}, got ${event.keys?.[0]}`,
-      );
-    }
-
-    return null as DecodeEventReturn<TAbi, TEventName, TStrict>;
-  }
-
-  const keysAbi = eventAbi.members.filter((m) => m.kind === "key");
-  const dataAbi = eventAbi.members.filter((m) => m.kind === "data");
 
   try {
-    const keysParser = compileEventMembers(abi, keysAbi);
-    const dataParser = compileEventMembers(abi, dataAbi);
-
-    const keysWithoutSelector = event.keys?.slice(1) ?? [];
-    const { out: decodedKeys } = keysParser(keysWithoutSelector, 0);
-    const { out: decodedData } = dataParser(event.data ?? [], 0);
-
-    const decoded = {
-      ...decodedKeys,
-      ...decodedData,
-    } as EventToPrimitiveType<TAbi, TEventName>;
-
-    return {
-      ...event,
-      eventName,
-      args: decoded,
-    } as DecodedEvent<TAbi, TEventName>;
-  } catch (error) {
-    if (error instanceof DecodeEventError && !strict) {
-      return null as DecodeEventReturn<TAbi, TEventName, TStrict>;
+    if (isStructEventAbi(eventAbi)) {
+      return decodeStructEvent(abi, eventAbi, event, eventName);
     }
 
-    if (error instanceof ParseError && !strict) {
+    if (isEnumEventAbi(eventAbi)) {
+      return decodeEnumEvent(abi, eventAbi, event, eventName);
+    }
+
+    throw new DecodeEventError(
+      `Unsupported event kind: ${(eventAbi as AbiEvent)?.kind}`,
+    );
+  } catch (error) {
+    if (
+      (error instanceof DecodeEventError || error instanceof ParseError) &&
+      !strict
+    ) {
       return null as DecodeEventReturn<TAbi, TEventName, TStrict>;
     }
 
     throw error;
   }
+}
+
+function decodeStructEvent<
+  TAbi extends Abi = Abi,
+  TEventName extends ExtractAbiEventNames<TAbi> = ExtractAbiEventNames<TAbi>,
+>(
+  abi: TAbi,
+  eventAbi: AbiEventStruct,
+  event: Event,
+  eventName: TEventName,
+): DecodedEvent<TAbi, TEventName> {
+  const selector = BigInt(getEventSelector(eventName));
+  if ((event.keys && selector !== BigInt(event.keys[0])) || !event.keys) {
+    throw new DecodeEventError(
+      `Selector mismatch. Expected ${selector}, got ${event.keys?.[0]}`,
+    );
+  }
+
+  const keysAbi = eventAbi.members.filter((m) => m.kind === "key");
+  const dataAbi = eventAbi.members.filter((m) => m.kind === "data");
+
+  const keysParser = compileEventMembers(abi, keysAbi);
+  const dataParser = compileEventMembers(abi, dataAbi);
+
+  const keysWithoutSelector = event.keys?.slice(1) ?? [];
+
+  const { out: decodedKeys } = keysParser(keysWithoutSelector, 0);
+  const { out: decodedData } = dataParser(event.data ?? [], 0);
+
+  const decoded = {
+    ...decodedKeys,
+    ...decodedData,
+  } as EventToPrimitiveType<TAbi, TEventName>;
+
+  return {
+    ...event,
+    eventName,
+    args: decoded,
+  } as DecodedEvent<TAbi, TEventName>;
+}
+
+function decodeEnumEvent<
+  TAbi extends Abi = Abi,
+  TEventName extends ExtractAbiEventNames<TAbi> = ExtractAbiEventNames<TAbi>,
+>(
+  abi: TAbi,
+  eventAbi: AbiEventEnum,
+  event: Event,
+  eventName: TEventName,
+): DecodedEvent<TAbi, TEventName> {
+  const variants = eventAbi.variants;
+
+  const variantSelector = event.keys[0];
+
+  // Create a map of all possible selectors to their variant paths
+  const selectorToVariant = buildVariantSelectorMap(abi, variants);
+
+  // Find the matching variant and path
+  const matchingVariant = selectorToVariant[variantSelector];
+
+  if (!matchingVariant) {
+    throw new DecodeEventError(
+      `No matching variant found for selector: ${variantSelector}`,
+    );
+  }
+
+  const structEventAbi = abi.find(
+    (item) =>
+      item.name === matchingVariant.variant.type && item.type === "event",
+  );
+
+  if (!structEventAbi || !isStructEventAbi(structEventAbi)) {
+    throw new DecodeEventError(
+      `Nested event type not found or not a struct: ${matchingVariant.variant.type}`,
+    );
+  }
+
+  const decodedStruct = decodeStructEvent(
+    abi,
+    structEventAbi,
+    event,
+    matchingVariant.variant.name,
+  );
+
+  return {
+    ...event,
+    eventName,
+    args: {
+      _tag: matchingVariant.variant.name,
+      [matchingVariant.variant.name]: decodedStruct.args,
+    },
+  } as DecodedEvent<TAbi, TEventName>;
+}
+
+type EnumFlatVariantMap = Record<
+  string,
+  { variant: AbiEventMember; path: string[] }
+>;
+
+// Helper to build a map of all possible selectors to their variant paths
+function buildVariantSelectorMap(
+  abi: Abi,
+  variants: AbiEventMember[],
+): EnumFlatVariantMap {
+  const selectorMap: EnumFlatVariantMap = {};
+
+  for (const variant of variants) {
+    // For nested events, just map the variant's own selector
+    if (variant.kind === "nested") {
+      const selector = getEventSelector(variant.name);
+      selectorMap[selector] = { variant, path: [variant.name] };
+    }
+    // For flat events, recursively map all possible selectors from the event hierarchy
+    else if (variant.kind === "flat") {
+      const flatEventName = variant.type;
+      const flatEventAbi = abi.find(
+        (item) => item.name === flatEventName && item.type === "event",
+      );
+
+      // Skip if the flat event type is not found
+      if (!flatEventAbi) {
+        continue;
+      }
+
+      if (isEnumEventAbi(flatEventAbi)) {
+        // For enum events, recursively map all their variants
+        const nestedMap = buildVariantSelectorMap(abi, flatEventAbi.variants);
+
+        // Add this variant to the path for all nested selectors
+        for (const [
+          nestedSelector,
+          { variant: nestedVariant, path: nestedPath },
+        ] of Object.entries(nestedMap)) {
+          selectorMap[nestedSelector] = {
+            variant: nestedVariant,
+            path: [variant.name, ...nestedPath],
+          };
+        }
+      }
+    }
+  }
+
+  return selectorMap;
 }
 
 function compileEventMembers<T extends Record<string, unknown>>(
@@ -176,17 +302,15 @@ function compileTypeParser(abi: Abi, type: string): Parser<unknown> {
     case "struct": {
       return compileStructParser(abi, typeAbi.members);
     }
-    case "enum":
-      throw new DecodeEventError("enum: not implemented");
+    case "enum": {
+      // This should never happen anyways as compileTypeParser is only called
+      // primitive types or to compile structs parsers.
+      throw new DecodeEventError(`Enum types are not supported: ${type}`);
+    }
     default:
       throw new DecodeEventError(`Invalid type ${typeAbi.type}`);
   }
 }
-
-type AbiMember = {
-  name: string;
-  type: string;
-};
 
 function compileStructParser(
   abi: Abi,

--- a/packages/starknet/src/event.ts
+++ b/packages/starknet/src/event.ts
@@ -166,6 +166,12 @@ function decodeEnumEvent<
   event: Event,
   eventName: TEventName,
 ): DecodedEvent<TAbi, TEventName> {
+  if (!event.keys || event.keys.length === 0) {
+    throw new DecodeEventError(
+      "Event has no keys; cannot determine variant selector",
+    );
+  }
+
   const variants = eventAbi.variants;
 
   const variantSelector = event.keys[0];

--- a/packages/starknet/src/index.ts
+++ b/packages/starknet/src/index.ts
@@ -15,6 +15,8 @@ export { getBigIntSelector, getEventSelector, getSelector } from "./abi";
 
 declare module "abi-wan-kanabi" {
   interface Config {
+    AddressType: `0x${string}`;
+    ClassHashType: `0x${string}`;
     FeltType: bigint;
     BigIntType: bigint;
     U256Type: bigint;

--- a/packages/starknet/src/parser.test-d.ts
+++ b/packages/starknet/src/parser.test-d.ts
@@ -1,0 +1,63 @@
+import { describe, expectTypeOf, it } from "vitest";
+import {
+  parseArray,
+  parseBool,
+  parseContractAddress,
+  parseEthAddress,
+  parseOption,
+  parseStruct,
+  parseTuple,
+  parseU8,
+  parseU256,
+} from "./parser";
+
+describe("Array parser", () => {
+  it("has the type of the inner parser", () => {
+    const { out } = parseArray(parseU256)([], 0);
+    expectTypeOf(out).toMatchTypeOf<bigint[]>();
+  });
+});
+
+describe("Option parser", () => {
+  it("has the type of the inner parser", () => {
+    const { out } = parseOption(parseContractAddress)([], 0);
+
+    expectTypeOf(out).toMatchTypeOf<`0x${string}` | null>();
+  });
+});
+
+describe("Struct parser", () => {
+  it("parses simple structs ", () => {
+    const { out } = parseStruct({
+      a: { index: 0, parser: parseEthAddress },
+      b: { index: 1, parser: parseOption(parseU256) },
+    })([], 0);
+
+    expectTypeOf(out).toMatchTypeOf<{ a: `0x${string}`; b: bigint | null }>();
+  });
+
+  it("parses nested structs", () => {
+    const parseN = parseStruct({
+      x: { index: 0, parser: parseU8 },
+      y: { index: 1, parser: parseBool },
+    });
+
+    const { out } = parseStruct({
+      a: { index: 0, parser: parseArray(parseN) },
+      b: { index: 1, parser: parseN },
+    })([], 0);
+
+    expectTypeOf(out).toMatchTypeOf<{
+      a: { x: bigint; y: boolean }[];
+      b: { x: bigint; y: boolean };
+    }>();
+  });
+});
+
+describe("Tuple parser", () => {
+  it("has the type of the inner parser", () => {
+    const { out } = parseTuple(parseU256, parseEthAddress)([], 0);
+
+    expectTypeOf(out).toMatchTypeOf<[bigint, `0x${string}`]>();
+  });
+});

--- a/packages/starknet/src/parser.ts
+++ b/packages/starknet/src/parser.ts
@@ -77,7 +77,7 @@ export function parseU256(data: readonly FieldElement[], offset: number) {
 export function parseAsHex(data: readonly FieldElement[], offset: number) {
   assertInBounds(data, offset);
   return {
-    out: String(data[offset]),
+    out: data[offset],
     offset: offset + 1,
   };
 }
@@ -96,7 +96,7 @@ export function parseFelt252(data: readonly FieldElement[], offset: number) {
   };
 }
 
-export function parseEmpty(data: readonly FieldElement[], offset: number) {
+export function parseEmpty(_data: readonly FieldElement[], offset: number) {
   return { out: null, offset };
 }
 
@@ -132,13 +132,13 @@ export function parseOption<T>(type: Parser<T>) {
   };
 }
 
-export function parseStruct<T extends { [key: string]: unknown }>(
+export function parseStruct<T extends Record<string, unknown>>(
   parsers: { [K in keyof T]: { index: number; parser: Parser<T[K]> } },
-) {
+): Parser<{ [K in keyof T]: T[K] }> {
   const sortedParsers = Object.entries(parsers).sort(
     (a, b) => a[1].index - b[1].index,
   );
-  return (data: readonly FieldElement[], startingOffset: number) => {
+  const parser = (data: readonly FieldElement[], startingOffset: number) => {
     let offset = startingOffset;
     const out: Record<string, unknown> = {};
     for (const [key, { parser }] of sortedParsers) {
@@ -148,6 +148,7 @@ export function parseStruct<T extends { [key: string]: unknown }>(
     }
     return { out, offset };
   };
+  return parser as Parser<{ [K in keyof T]: T[K] }>;
 }
 
 export function parseTuple<T extends Parser<unknown>[]>(

--- a/packages/starknet/tests/event.test-d.ts
+++ b/packages/starknet/tests/event.test-d.ts
@@ -1,4 +1,5 @@
 import { describe, expectTypeOf, it } from "vitest";
+import type { EventToPrimitiveType } from "../src/abi-wan-helpers";
 import type { Event } from "../src/block";
 import { decodeEvent } from "../src/event";
 import { ekuboAbi } from "./fixtures/ekubo-abi";
@@ -40,7 +41,8 @@ describe("decodeEvent", () => {
       event: {} as Event,
     });
 
-    // TODO: fill this.
-    expectTypeOf(decoded.args).toEqualTypeOf<{ fixme: unknown }>();
+    expectTypeOf(decoded.args).toEqualTypeOf<
+      EventToPrimitiveType<typeof ekuboAbi, "ekubo::core::Core::Event">
+    >();
   });
 });

--- a/packages/starknet/tests/event.test-d.ts
+++ b/packages/starknet/tests/event.test-d.ts
@@ -1,0 +1,46 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type { Event } from "../src/block";
+import { decodeEvent } from "../src/event";
+import { ekuboAbi } from "./fixtures/ekubo-abi";
+
+describe("decodeEvent", () => {
+  it("errors if the event does not exist", () => {
+    const abi = ekuboAbi;
+
+    const _decoded = decodeEvent({
+      abi,
+      // @ts-expect-error event does not exist
+      eventName: "xxxx",
+      event: {} as Event,
+      strict: false,
+    });
+  });
+
+  it("types the decoded event", () => {
+    const abi = ekuboAbi;
+
+    const decoded = decodeEvent({
+      abi,
+      eventName: "ekubo::core::Core::SavedBalance",
+      event: {} as Event,
+    });
+
+    expectTypeOf(decoded.args).toEqualTypeOf<{
+      key: { owner: `0x${string}`; token: `0x${string}`; salt: bigint };
+      amount: bigint;
+    }>();
+  });
+
+  it("types the root event", () => {
+    const abi = ekuboAbi;
+
+    const decoded = decodeEvent({
+      abi,
+      eventName: "ekubo::core::Core::Event",
+      event: {} as Event,
+    });
+
+    // TODO: fill this.
+    expectTypeOf(decoded.args).toEqualTypeOf<{ fixme: unknown }>();
+  });
+});

--- a/packages/starknet/tests/event.test.ts
+++ b/packages/starknet/tests/event.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import type { Event } from "../src/block";
 import { decodeEvent } from "../src/event";
+
+import { getEventSelector } from "../src";
 import { chainlinkAbi } from "./fixtures/chainlink-abi";
 import { ekuboAbi } from "./fixtures/ekubo-abi";
+import { golifeAbi } from "./fixtures/golife-abi";
 
 describe("decodeEvent", () => {
   describe("non strict mode", () => {
@@ -203,17 +206,15 @@ describe("decodeEvent", () => {
           "0x0",
           "0x0",
         ],
-        "eventIndex": 1893,
-        "eventIndexInTransaction": 6,
+        "eventIndex": 0,
+        "eventIndexInTransaction": 0,
         "eventName": "ekubo::core::Core::PositionUpdated",
-        "filterIds": [
-          0,
-        ],
+        "filterIds": [],
         "keys": [
           "0x3a7adca3546c213ce791fabf3b04090c163e419c808c9830fb343a4a395946e",
         ],
         "transactionHash": "0x008691c1fa0f5c650b3492396dc1c22423c04e9a8843a12eaab03799d0a45cd0",
-        "transactionIndex": 318,
+        "transactionIndex": 0,
         "transactionStatus": "succeeded",
       }
     `);
@@ -325,8 +326,278 @@ describe("decodeEvent", () => {
         ],
         "transactionHash": "0x07021da0c8e9319d1144b0d56ed0bd86e46b15459cbb65c4dc0a05c8e274521d",
         "transactionIndex": 0,
-        "transactionStatus": "unknown",
+        "transactionStatus": "succeeded",
       }
     `);
+  });
+
+  describe("Enum event decoding", () => {
+    it("can decode RoleGranted (flat) event from enum", () => {
+      const abi = golifeAbi;
+
+      const roleGrantedEventSelector = getEventSelector("RoleGranted");
+
+      const event = {
+        transactionHash:
+          "0x068b0a81f96d16e1b90d994d7e47e187770bcbc07257495e50fb3396712d9101",
+        address:
+          "0x00f92d3789e679e4ac8e94472ec6a67a63b99d042f772a0227b0d6bd241096c2",
+        keys: [roleGrantedEventSelector],
+        data: [
+          "0x0", // Role Data
+          "0x76e65f2bea9d559196eb91e967e8c4f43b4503198978bf672d10149b70cc1c6", // Account data
+          "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf", // Sender data
+        ],
+        filterIds: [],
+        eventIndex: 0,
+        eventIndexInTransaction: 0,
+        transactionIndex: 0,
+        transactionStatus: "succeeded",
+      } as const satisfies Event;
+
+      const decoded = decodeEvent({
+        abi,
+        event,
+        eventName: "gol_starknet::gol_lifeforms::GolLifeforms::Event",
+        strict: false,
+      });
+
+      expect(decoded).toMatchInlineSnapshot(`
+        {
+          "address": "0x00f92d3789e679e4ac8e94472ec6a67a63b99d042f772a0227b0d6bd241096c2",
+          "args": {
+            "RoleGranted": {
+              "account": "0x76e65f2bea9d559196eb91e967e8c4f43b4503198978bf672d10149b70cc1c6",
+              "role": 0n,
+              "sender": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+            },
+            "_tag": "RoleGranted",
+          },
+          "data": [
+            "0x0",
+            "0x76e65f2bea9d559196eb91e967e8c4f43b4503198978bf672d10149b70cc1c6",
+            "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+          ],
+          "eventIndex": 0,
+          "eventIndexInTransaction": 0,
+          "eventName": "gol_starknet::gol_lifeforms::GolLifeforms::Event",
+          "filterIds": [],
+          "keys": [
+            "0x009d4a59b844ac9d98627ddba326ab3707a7d7e105fd03c777569d0f61a91f1e",
+          ],
+          "transactionHash": "0x068b0a81f96d16e1b90d994d7e47e187770bcbc07257495e50fb3396712d9101",
+          "transactionIndex": 0,
+          "transactionStatus": "succeeded",
+        }
+      `);
+    });
+
+    it("can decode Transfer (flat) event from enum", () => {
+      const abi = golifeAbi;
+      const transferEventSelector = getEventSelector("Transfer");
+      const event = {
+        transactionHash:
+          "0x02e0abd9a260095622f71ff8869aaee0267af1199be78ad5ad91a3c83df0ad08",
+        address:
+          "0x00f92d3789e679e4ac8e94472ec6a67a63b99d042f772a0227b0d6bd241096c2",
+        keys: [
+          transferEventSelector,
+          "0x0",
+          "0x76e65f2bea9d559196eb91e967e8c4f43b4503198978bf672d10149b70cc1c6",
+          "0xe000000",
+          "0x0",
+        ],
+        data: [],
+        filterIds: [],
+        eventIndex: 0,
+        eventIndexInTransaction: 0,
+        transactionIndex: 0,
+        transactionStatus: "succeeded",
+      } as const satisfies Event;
+
+      const decoded = decodeEvent({
+        abi,
+        event,
+        eventName: "gol_starknet::gol_lifeforms::GolLifeforms::Event",
+        strict: true,
+      });
+
+      expect(decoded).toMatchInlineSnapshot(`
+        {
+          "address": "0x00f92d3789e679e4ac8e94472ec6a67a63b99d042f772a0227b0d6bd241096c2",
+          "args": {
+            "Transfer": {
+              "from": "0x0",
+              "to": "0x76e65f2bea9d559196eb91e967e8c4f43b4503198978bf672d10149b70cc1c6",
+              "token_id": 234881024n,
+            },
+            "_tag": "Transfer",
+          },
+          "data": [],
+          "eventIndex": 0,
+          "eventIndexInTransaction": 0,
+          "eventName": "gol_starknet::gol_lifeforms::GolLifeforms::Event",
+          "filterIds": [],
+          "keys": [
+            "0x0099cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9",
+            "0x0",
+            "0x76e65f2bea9d559196eb91e967e8c4f43b4503198978bf672d10149b70cc1c6",
+            "0xe000000",
+            "0x0",
+          ],
+          "transactionHash": "0x02e0abd9a260095622f71ff8869aaee0267af1199be78ad5ad91a3c83df0ad08",
+          "transactionIndex": 0,
+          "transactionStatus": "succeeded",
+        }
+      `);
+    });
+
+    it("can decode NewLifeForm (nested) event from enum", () => {
+      const abi = golifeAbi;
+      const newLifeFormEventSelector = getEventSelector("NewLifeForm");
+      const event = {
+        transactionHash:
+          "0x02e0abd9a260095622f71ff8869aaee0267af1199be78ad5ad91a3c83df0ad08",
+        address:
+          "0x00f92d3789e679e4ac8e94472ec6a67a63b99d042f772a0227b0d6bd241096c2",
+        keys: [newLifeFormEventSelector],
+        data: [
+          "0x76e65f2bea9d559196eb91e967e8c4f43b4503198978bf672d10149b70cc1c6",
+          "0xe000000",
+          "0x0",
+          "0x1",
+          "0x0",
+          "0x1",
+          "0x0",
+          "0x2",
+          "0xe000000",
+          "0x0",
+          "0x0",
+        ],
+        filterIds: [],
+        eventIndex: 0,
+        eventIndexInTransaction: 0,
+        transactionIndex: 0,
+        transactionStatus: "succeeded",
+      } as const satisfies Event;
+
+      const decoded = decodeEvent({
+        abi,
+        event,
+        eventName: "gol_starknet::gol_lifeforms::GolLifeforms::Event",
+        strict: true,
+      });
+
+      expect(decoded).toMatchInlineSnapshot(`
+        {
+          "address": "0x00f92d3789e679e4ac8e94472ec6a67a63b99d042f772a0227b0d6bd241096c2",
+          "args": {
+            "NewLifeForm": {
+              "lifeform_data": {
+                "age": 0n,
+                "current_state": 234881024n,
+                "is_alive": true,
+                "is_dead": false,
+                "is_loop": true,
+                "is_still": false,
+                "sequence_length": 2n,
+              },
+              "owner": "0x76e65f2bea9d559196eb91e967e8c4f43b4503198978bf672d10149b70cc1c6",
+              "token_id": 234881024n,
+            },
+            "_tag": "NewLifeForm",
+          },
+          "data": [
+            "0x76e65f2bea9d559196eb91e967e8c4f43b4503198978bf672d10149b70cc1c6",
+            "0xe000000",
+            "0x0",
+            "0x1",
+            "0x0",
+            "0x1",
+            "0x0",
+            "0x2",
+            "0xe000000",
+            "0x0",
+            "0x0",
+          ],
+          "eventIndex": 0,
+          "eventIndexInTransaction": 0,
+          "eventName": "gol_starknet::gol_lifeforms::GolLifeforms::Event",
+          "filterIds": [],
+          "keys": [
+            "0x011f46882e19ad05d3762feda18b95af02b4d04ff264650de9665ede8f823262",
+          ],
+          "transactionHash": "0x02e0abd9a260095622f71ff8869aaee0267af1199be78ad5ad91a3c83df0ad08",
+          "transactionIndex": 0,
+          "transactionStatus": "succeeded",
+        }
+      `);
+    });
+
+    it("returns null when selector does not match in enum event", () => {
+      const abi = golifeAbi;
+      const transferEventSelector = getEventSelector("XXXX");
+      const event = {
+        transactionHash:
+          "0x02e0abd9a260095622f71ff8869aaee0267af1199be78ad5ad91a3c83df0ad08",
+        address:
+          "0x00f92d3789e679e4ac8e94472ec6a67a63b99d042f772a0227b0d6bd241096c2",
+        keys: [
+          transferEventSelector,
+          "0x0",
+          "0x76e65f2bea9d559196eb91e967e8c4f43b4503198978bf672d10149b70cc1c6",
+          "0xe000000",
+          "0x0",
+        ],
+        data: [],
+        filterIds: [],
+        eventIndex: 0,
+        eventIndexInTransaction: 0,
+        transactionIndex: 0,
+        transactionStatus: "succeeded",
+      } as const satisfies Event;
+
+      const decoded = decodeEvent({
+        abi,
+        event,
+        eventName: "gol_starknet::gol_lifeforms::GolLifeforms::Event",
+        strict: false,
+      });
+
+      expect(decoded).toBeNull();
+    });
+
+    it("returns null if parsing fails for enum event", () => {
+      const abi = golifeAbi;
+
+      const roleGrantedEventSelector = getEventSelector("RoleGranted");
+
+      const event = {
+        transactionHash:
+          "0x068b0a81f96d16e1b90d994d7e47e187770bcbc07257495e50fb3396712d9101",
+        address:
+          "0x00f92d3789e679e4ac8e94472ec6a67a63b99d042f772a0227b0d6bd241096c2",
+        keys: [roleGrantedEventSelector],
+        data: [
+          "0x0", // Role Data
+          "0x76e65f2bea9d559196eb91e967e8c4f43b4503198978bf672d10149b70cc1c6",
+          // Missing data
+        ],
+        filterIds: [],
+        eventIndex: 0,
+        eventIndexInTransaction: 0,
+        transactionIndex: 0,
+        transactionStatus: "succeeded",
+      } as const satisfies Event;
+
+      const decoded = decodeEvent({
+        abi,
+        event,
+        eventName: "gol_starknet::gol_lifeforms::GolLifeforms::Event",
+        strict: false,
+      });
+
+      expect(decoded).toBeNull();
+    });
   });
 });

--- a/packages/starknet/tests/event.test.ts
+++ b/packages/starknet/tests/event.test.ts
@@ -37,11 +37,11 @@ describe("decodeEvent", () => {
           "0x0",
           "0x0",
         ],
-        eventIndex: 1893,
-        transactionIndex: 318,
+        filterIds: [],
+        eventIndex: 0,
+        eventIndexInTransaction: 0,
+        transactionIndex: 0,
         transactionStatus: "succeeded",
-        eventIndexInTransaction: 6,
-        filterIds: [0],
       } as const satisfies Event;
 
       const decoded = decodeEvent({
@@ -83,11 +83,11 @@ describe("decodeEvent", () => {
           "0x0",
           "0x0",
         ],
-        eventIndex: 1893,
-        transactionIndex: 318,
+        filterIds: [],
+        eventIndex: 0,
+        eventIndexInTransaction: 0,
+        transactionIndex: 0,
         transactionStatus: "succeeded",
-        eventIndexInTransaction: 6,
-        filterIds: [0],
       } as const satisfies Event;
 
       const decoded = decodeEvent({
@@ -131,11 +131,11 @@ describe("decodeEvent", () => {
         "0x0",
         "0x0",
       ],
-      eventIndex: 1893,
-      transactionIndex: 318,
+      filterIds: [],
+      eventIndex: 0,
+      eventIndexInTransaction: 0,
+      transactionIndex: 0,
       transactionStatus: "succeeded",
-      eventIndexInTransaction: 6,
-      filterIds: [0],
     } as const satisfies Event;
 
     const decoded = decodeEvent({
@@ -253,11 +253,11 @@ describe("decodeEvent", () => {
         "0x1ee0005",
         "0x0",
       ],
-      eventIndex: 0,
-      transactionIndex: 0,
-      transactionStatus: "unknown",
-      eventIndexInTransaction: 0,
       filterIds: [],
+      eventIndex: 0,
+      eventIndexInTransaction: 0,
+      transactionIndex: 0,
+      transactionStatus: "succeeded",
     } as const satisfies Event;
 
     const decoded = decodeEvent({

--- a/packages/starknet/tests/fixtures/ekubo-abi.ts
+++ b/packages/starknet/tests/fixtures/ekubo-abi.ts
@@ -1,4 +1,4 @@
-import type { Abi } from "abi-wan-kanabi";
+import type { Abi } from "../../src/index";
 
 export const ekuboAbi = [
   {

--- a/packages/starknet/tests/fixtures/golife-abi.ts
+++ b/packages/starknet/tests/fixtures/golife-abi.ts
@@ -1,0 +1,1209 @@
+import type { Abi } from "../../src/index";
+
+export const golifeAbi = [
+  {
+    name: "GolLifeFormsImpl",
+    type: "impl",
+    interface_name: "gol_starknet::interfaces::IGolLifeForms",
+  },
+  {
+    name: "core::integer::u256",
+    type: "struct",
+    members: [
+      {
+        name: "low",
+        type: "core::integer::u128",
+      },
+      {
+        name: "high",
+        type: "core::integer::u128",
+      },
+    ],
+  },
+  {
+    name: "core::bool",
+    type: "enum",
+    variants: [
+      {
+        name: "False",
+        type: "()",
+      },
+      {
+        name: "True",
+        type: "()",
+      },
+    ],
+  },
+  {
+    name: "gol_starknet::interfaces::LifeFormData",
+    type: "struct",
+    members: [
+      {
+        name: "is_loop",
+        type: "core::bool",
+      },
+      {
+        name: "is_still",
+        type: "core::bool",
+      },
+      {
+        name: "is_alive",
+        type: "core::bool",
+      },
+      {
+        name: "is_dead",
+        type: "core::bool",
+      },
+      {
+        name: "sequence_length",
+        type: "core::integer::u32",
+      },
+      {
+        name: "current_state",
+        type: "core::integer::u256",
+      },
+      {
+        name: "age",
+        type: "core::integer::u32",
+      },
+    ],
+  },
+  {
+    name: "gol_starknet::interfaces::IGolLifeForms",
+    type: "interface",
+    items: [
+      {
+        name: "mint",
+        type: "function",
+        inputs: [
+          {
+            name: "recipient",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "minter",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "token_id",
+            type: "core::integer::u256",
+          },
+          {
+            name: "lifeform_data",
+            type: "gol_starknet::interfaces::LifeFormData",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        name: "get_lifeform_data",
+        type: "function",
+        inputs: [
+          {
+            name: "token_id",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [
+          {
+            type: "gol_starknet::interfaces::LifeFormData",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "move_lifeform_forward",
+        type: "function",
+        inputs: [
+          {
+            name: "token_id",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        name: "get_nutrient_contract_address",
+        type: "function",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        state_mutability: "view",
+      },
+    ],
+  },
+  {
+    name: "UpgradeableImpl",
+    type: "impl",
+    interface_name: "openzeppelin_upgrades::interface::IUpgradeable",
+  },
+  {
+    name: "openzeppelin_upgrades::interface::IUpgradeable",
+    type: "interface",
+    items: [
+      {
+        name: "upgrade",
+        type: "function",
+        inputs: [
+          {
+            name: "new_class_hash",
+            type: "core::starknet::class_hash::ClassHash",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+    ],
+  },
+  {
+    name: "ERC721MixinImpl",
+    type: "impl",
+    interface_name: "openzeppelin_token::erc721::interface::ERC721ABI",
+  },
+  {
+    name: "core::array::Span::<core::felt252>",
+    type: "struct",
+    members: [
+      {
+        name: "snapshot",
+        type: "@core::array::Array::<core::felt252>",
+      },
+    ],
+  },
+  {
+    name: "core::byte_array::ByteArray",
+    type: "struct",
+    members: [
+      {
+        name: "data",
+        type: "core::array::Array::<core::bytes_31::bytes31>",
+      },
+      {
+        name: "pending_word",
+        type: "core::felt252",
+      },
+      {
+        name: "pending_word_len",
+        type: "core::integer::u32",
+      },
+    ],
+  },
+  {
+    name: "openzeppelin_token::erc721::interface::ERC721ABI",
+    type: "interface",
+    items: [
+      {
+        name: "balance_of",
+        type: "function",
+        inputs: [
+          {
+            name: "account",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::integer::u256",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "owner_of",
+        type: "function",
+        inputs: [
+          {
+            name: "token_id",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "safe_transfer_from",
+        type: "function",
+        inputs: [
+          {
+            name: "from",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "to",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "token_id",
+            type: "core::integer::u256",
+          },
+          {
+            name: "data",
+            type: "core::array::Span::<core::felt252>",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        name: "transfer_from",
+        type: "function",
+        inputs: [
+          {
+            name: "from",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "to",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "token_id",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        name: "approve",
+        type: "function",
+        inputs: [
+          {
+            name: "to",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "token_id",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        name: "set_approval_for_all",
+        type: "function",
+        inputs: [
+          {
+            name: "operator",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "approved",
+            type: "core::bool",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        name: "get_approved",
+        type: "function",
+        inputs: [
+          {
+            name: "token_id",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "is_approved_for_all",
+        type: "function",
+        inputs: [
+          {
+            name: "owner",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "operator",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "supports_interface",
+        type: "function",
+        inputs: [
+          {
+            name: "interface_id",
+            type: "core::felt252",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "name",
+        type: "function",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::byte_array::ByteArray",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "symbol",
+        type: "function",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::byte_array::ByteArray",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "token_uri",
+        type: "function",
+        inputs: [
+          {
+            name: "token_id",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::byte_array::ByteArray",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "balanceOf",
+        type: "function",
+        inputs: [
+          {
+            name: "account",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::integer::u256",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "ownerOf",
+        type: "function",
+        inputs: [
+          {
+            name: "tokenId",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "safeTransferFrom",
+        type: "function",
+        inputs: [
+          {
+            name: "from",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "to",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "tokenId",
+            type: "core::integer::u256",
+          },
+          {
+            name: "data",
+            type: "core::array::Span::<core::felt252>",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        name: "transferFrom",
+        type: "function",
+        inputs: [
+          {
+            name: "from",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "to",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "tokenId",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        name: "setApprovalForAll",
+        type: "function",
+        inputs: [
+          {
+            name: "operator",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "approved",
+            type: "core::bool",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        name: "getApproved",
+        type: "function",
+        inputs: [
+          {
+            name: "tokenId",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "isApprovedForAll",
+        type: "function",
+        inputs: [
+          {
+            name: "owner",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "operator",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "tokenURI",
+        type: "function",
+        inputs: [
+          {
+            name: "tokenId",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::byte_array::ByteArray",
+          },
+        ],
+        state_mutability: "view",
+      },
+    ],
+  },
+  {
+    name: "AccessControlImpl",
+    type: "impl",
+    interface_name:
+      "openzeppelin_access::accesscontrol::interface::IAccessControl",
+  },
+  {
+    name: "openzeppelin_access::accesscontrol::interface::IAccessControl",
+    type: "interface",
+    items: [
+      {
+        name: "has_role",
+        type: "function",
+        inputs: [
+          {
+            name: "role",
+            type: "core::felt252",
+          },
+          {
+            name: "account",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "get_role_admin",
+        type: "function",
+        inputs: [
+          {
+            name: "role",
+            type: "core::felt252",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::felt252",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "grant_role",
+        type: "function",
+        inputs: [
+          {
+            name: "role",
+            type: "core::felt252",
+          },
+          {
+            name: "account",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        name: "revoke_role",
+        type: "function",
+        inputs: [
+          {
+            name: "role",
+            type: "core::felt252",
+          },
+          {
+            name: "account",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        name: "renounce_role",
+        type: "function",
+        inputs: [
+          {
+            name: "role",
+            type: "core::felt252",
+          },
+          {
+            name: "account",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+    ],
+  },
+  {
+    name: "GolUtilitiesImpl",
+    type: "impl",
+    interface_name: "gol_starknet::interfaces::IGolUtilities",
+  },
+  {
+    name: "gol_starknet::interfaces::PartialPathData",
+    type: "struct",
+    members: [
+      {
+        name: "entrypoint",
+        type: "core::integer::u256",
+      },
+      {
+        name: "exitpoint",
+        type: "core::integer::u256",
+      },
+      {
+        name: "length",
+        type: "core::integer::u32",
+      },
+      {
+        name: "trigger_state",
+        type: "core::integer::u256",
+      },
+      {
+        name: "smallest_element",
+        type: "core::integer::u256",
+      },
+    ],
+  },
+  {
+    name: "gol_starknet::interfaces::IGolUtilities",
+    type: "interface",
+    items: [
+      {
+        name: "unpack_grid_from_uint",
+        type: "function",
+        inputs: [
+          {
+            name: "state",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::array::Array::<core::array::Array::<core::bool>>",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "pack_grid_in_uint",
+        type: "function",
+        inputs: [
+          {
+            name: "grid",
+            type: "core::array::Array::<core::array::Array::<core::bool>>",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::integer::u256",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "iterate_life_once",
+        type: "function",
+        inputs: [
+          {
+            name: "initial_state",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::integer::u256",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "iterate_life_several_times",
+        type: "function",
+        inputs: [
+          {
+            name: "initial_state",
+            type: "core::integer::u256",
+          },
+          {
+            name: "generations",
+            type: "core::integer::u32",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::array::Array::<core::integer::u256>",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "iterate_life_several_times_enhanced",
+        type: "function",
+        inputs: [
+          {
+            name: "initial_state",
+            type: "core::integer::u256",
+          },
+          {
+            name: "trigger_state",
+            type: "core::integer::u256",
+          },
+          {
+            name: "generations",
+            type: "core::integer::u32",
+          },
+        ],
+        outputs: [
+          {
+            type: "(core::bool, core::integer::u256, core::array::Array::<core::integer::u256>)",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "is_single_loop_from_initial_state",
+        type: "function",
+        inputs: [
+          {
+            name: "initial_state",
+            type: "core::integer::u256",
+          },
+          {
+            name: "generations",
+            type: "core::integer::u32",
+          },
+        ],
+        outputs: [
+          {
+            type: "(core::bool, core::integer::u256, core::array::Array::<core::integer::u256>)",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "is_single_loop_and_entrypoint_is_smallest_from_initial_state",
+        type: "function",
+        inputs: [
+          {
+            name: "initial_state",
+            type: "core::integer::u256",
+          },
+          {
+            name: "generations",
+            type: "core::integer::u32",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "compute_partial_path",
+        type: "function",
+        inputs: [
+          {
+            name: "initial_state",
+            type: "core::integer::u256",
+          },
+          {
+            name: "trigger_state",
+            type: "core::integer::u256",
+          },
+          {
+            name: "generations",
+            type: "core::integer::u32",
+          },
+        ],
+        outputs: [
+          {
+            type: "gol_starknet::interfaces::PartialPathData",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "combine_partial_path",
+        type: "function",
+        inputs: [
+          {
+            name: "partial_path_1",
+            type: "gol_starknet::interfaces::PartialPathData",
+          },
+          {
+            name: "partial_path_2",
+            type: "gol_starknet::interfaces::PartialPathData",
+          },
+        ],
+        outputs: [
+          {
+            type: "gol_starknet::interfaces::PartialPathData",
+          },
+        ],
+        state_mutability: "view",
+      },
+    ],
+  },
+  {
+    name: "constructor",
+    type: "constructor",
+    inputs: [
+      {
+        name: "creator",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+  },
+  {
+    name: "update_nutrient_contract_address",
+    type: "function",
+    inputs: [
+      {
+        name: "nutrient_contract_address",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+    outputs: [],
+    state_mutability: "external",
+  },
+  {
+    name: "update_loop_minter_contract",
+    type: "function",
+    inputs: [
+      {
+        name: "loop_minter_contract",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+    outputs: [],
+    state_mutability: "external",
+  },
+  {
+    name: "update_path_minter_contract",
+    type: "function",
+    inputs: [
+      {
+        name: "path_minter_contract",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+    outputs: [],
+    state_mutability: "external",
+  },
+  {
+    kind: "struct",
+    name: "openzeppelin_token::erc721::erc721::ERC721Component::Transfer",
+    type: "event",
+    members: [
+      {
+        kind: "key",
+        name: "from",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        kind: "key",
+        name: "to",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        kind: "key",
+        name: "token_id",
+        type: "core::integer::u256",
+      },
+    ],
+  },
+  {
+    kind: "struct",
+    name: "openzeppelin_token::erc721::erc721::ERC721Component::Approval",
+    type: "event",
+    members: [
+      {
+        kind: "key",
+        name: "owner",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        kind: "key",
+        name: "approved",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        kind: "key",
+        name: "token_id",
+        type: "core::integer::u256",
+      },
+    ],
+  },
+  {
+    kind: "struct",
+    name: "openzeppelin_token::erc721::erc721::ERC721Component::ApprovalForAll",
+    type: "event",
+    members: [
+      {
+        kind: "key",
+        name: "owner",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        kind: "key",
+        name: "operator",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        kind: "data",
+        name: "approved",
+        type: "core::bool",
+      },
+    ],
+  },
+  {
+    kind: "enum",
+    name: "openzeppelin_token::erc721::erc721::ERC721Component::Event",
+    type: "event",
+    variants: [
+      {
+        kind: "nested",
+        name: "Transfer",
+        type: "openzeppelin_token::erc721::erc721::ERC721Component::Transfer",
+      },
+      {
+        kind: "nested",
+        name: "Approval",
+        type: "openzeppelin_token::erc721::erc721::ERC721Component::Approval",
+      },
+      {
+        kind: "nested",
+        name: "ApprovalForAll",
+        type: "openzeppelin_token::erc721::erc721::ERC721Component::ApprovalForAll",
+      },
+    ],
+  },
+  {
+    kind: "enum",
+    name: "openzeppelin_introspection::src5::SRC5Component::Event",
+    type: "event",
+    variants: [],
+  },
+  {
+    kind: "struct",
+    name: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleGranted",
+    type: "event",
+    members: [
+      {
+        kind: "data",
+        name: "role",
+        type: "core::felt252",
+      },
+      {
+        kind: "data",
+        name: "account",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        kind: "data",
+        name: "sender",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+  },
+  {
+    kind: "struct",
+    name: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleRevoked",
+    type: "event",
+    members: [
+      {
+        kind: "data",
+        name: "role",
+        type: "core::felt252",
+      },
+      {
+        kind: "data",
+        name: "account",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        kind: "data",
+        name: "sender",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+  },
+  {
+    kind: "struct",
+    name: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleAdminChanged",
+    type: "event",
+    members: [
+      {
+        kind: "data",
+        name: "role",
+        type: "core::felt252",
+      },
+      {
+        kind: "data",
+        name: "previous_admin_role",
+        type: "core::felt252",
+      },
+      {
+        kind: "data",
+        name: "new_admin_role",
+        type: "core::felt252",
+      },
+    ],
+  },
+  {
+    kind: "enum",
+    name: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::Event",
+    type: "event",
+    variants: [
+      {
+        kind: "nested",
+        name: "RoleGranted",
+        type: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleGranted",
+      },
+      {
+        kind: "nested",
+        name: "RoleRevoked",
+        type: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleRevoked",
+      },
+      {
+        kind: "nested",
+        name: "RoleAdminChanged",
+        type: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleAdminChanged",
+      },
+    ],
+  },
+  {
+    kind: "struct",
+    name: "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Upgraded",
+    type: "event",
+    members: [
+      {
+        kind: "data",
+        name: "class_hash",
+        type: "core::starknet::class_hash::ClassHash",
+      },
+    ],
+  },
+  {
+    kind: "enum",
+    name: "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Event",
+    type: "event",
+    variants: [
+      {
+        kind: "nested",
+        name: "Upgraded",
+        type: "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Upgraded",
+      },
+    ],
+  },
+  {
+    kind: "enum",
+    name: "gol_starknet::gol_utilities::GolUtilitiesComponent::Event",
+    type: "event",
+    variants: [],
+  },
+  {
+    kind: "struct",
+    name: "gol_starknet::gol_lifeforms::GolLifeforms::NewLifeFormEvent",
+    type: "event",
+    members: [
+      {
+        kind: "data",
+        name: "owner",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        kind: "data",
+        name: "token_id",
+        type: "core::integer::u256",
+      },
+      {
+        kind: "data",
+        name: "lifeform_data",
+        type: "gol_starknet::interfaces::LifeFormData",
+      },
+    ],
+  },
+  {
+    kind: "struct",
+    name: "gol_starknet::gol_lifeforms::GolLifeforms::NewMoveEvent",
+    type: "event",
+    members: [
+      {
+        kind: "data",
+        name: "token_id",
+        type: "core::integer::u256",
+      },
+      {
+        kind: "data",
+        name: "age",
+        type: "core::integer::u32",
+      },
+    ],
+  },
+  {
+    kind: "struct",
+    name: "gol_starknet::gol_lifeforms::GolLifeforms::NutrientContractUpdatedEvent",
+    type: "event",
+    members: [
+      {
+        kind: "data",
+        name: "nutrient_contract_address",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+  },
+  {
+    kind: "enum",
+    name: "gol_starknet::gol_lifeforms::GolLifeforms::Event",
+    type: "event",
+    variants: [
+      {
+        kind: "flat",
+        name: "ERC721Event",
+        type: "openzeppelin_token::erc721::erc721::ERC721Component::Event",
+      },
+      {
+        kind: "flat",
+        name: "SRC5Event",
+        type: "openzeppelin_introspection::src5::SRC5Component::Event",
+      },
+      {
+        kind: "flat",
+        name: "AccessControlEvent",
+        type: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::Event",
+      },
+      {
+        kind: "flat",
+        name: "UpgradeableEvent",
+        type: "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Event",
+      },
+      {
+        kind: "flat",
+        name: "GolUtilitiesEvent",
+        type: "gol_starknet::gol_utilities::GolUtilitiesComponent::Event",
+      },
+      {
+        kind: "nested",
+        name: "NewLifeForm",
+        type: "gol_starknet::gol_lifeforms::GolLifeforms::NewLifeFormEvent",
+      },
+      {
+        kind: "nested",
+        name: "NewMove",
+        type: "gol_starknet::gol_lifeforms::GolLifeforms::NewMoveEvent",
+      },
+      {
+        kind: "nested",
+        name: "NutrientContractUpdated",
+        type: "gol_starknet::gol_lifeforms::GolLifeforms::NutrientContractUpdatedEvent",
+      },
+    ],
+  },
+] as const satisfies Abi;

--- a/packages/starknet/tests/parser.test-d.ts
+++ b/packages/starknet/tests/parser.test-d.ts
@@ -9,7 +9,7 @@ import {
   parseTuple,
   parseU8,
   parseU256,
-} from "./parser";
+} from "../src/parser";
 
 describe("Array parser", () => {
   it("has the type of the inner parser", () => {


### PR DESCRIPTION
adds support for decoding enum events and respective tests, with added type-safety by extending `abi-wan-kanabi `