### PR TITLE
plugin-drizzle:  use table_name instead of TG_TABLE_NAME

### DIFF
--- a/change/@apibara-plugin-drizzle-b88e8ea3-ca72-4abc-948b-166a319064e7.json
+++ b/change/@apibara-plugin-drizzle-b88e8ea3-ca72-4abc-948b-166a319064e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "plugin-drizzle: use table_name instead of TG_TABLE_NAME",
+  "packageName": "@apibara/plugin-drizzle",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
The issue is that timescale db works by "splitting" a table into many chunks. The value of `TG_TABLE_NAME` is not the name of the table, but the name of the chunk. So now we pass the table name to the function.