### PR TITLE
indexer: fix reconnect on internal server errors

### DIFF
--- a/change/@apibara-indexer-6840c283-48ae-4a3f-a3e7-706e002bd6a1.json
+++ b/change/@apibara-indexer-6840c283-48ae-4a3f-a3e7-706e002bd6a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "indexer: fix reconnect on internal server errors",
+  "packageName": "@apibara/indexer",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-protocol-aa5f0bd5-4da3-47e9-997b-32940c921233.json
+++ b/change/@apibara-protocol-aa5f0bd5-4da3-47e9-997b-32940c921233.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "indexer: fix reconnect on internal server errors",
+  "packageName": "@apibara/protocol",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/protocol/src/client.ts
+++ b/packages/protocol/src/client.ts
@@ -16,7 +16,7 @@ import type { StreamConfig } from "./config";
 import { StatusRequest, StatusResponse } from "./status";
 import { type StreamDataRequest, StreamDataResponse } from "./stream";
 
-export { ClientError, Status, Metadata } from "nice-grpc";
+export { ClientError, ServerError, Status, Metadata } from "nice-grpc";
 
 const DEFAULT_TIMEOUT_MS = 45_000;
 


### PR DESCRIPTION
Earlier, we had a reconnect logic for only `ClientError` instance, which wouldn't work for `ServerError`. So added a check for the same. Now indexer will reconnect on both `ClientError` and `ServerError` with status `INTERNAL`.