### PR TITLE
cli: adds support for source-maps

### DIFF
--- a/change/apibara-72dcbda1-4e3a-4509-a2a0-3575ed36626f.json
+++ b/change/apibara-72dcbda1-4e3a-4509-a2a0-3575ed36626f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "cli: add source map support",
+  "packageName": "apibara",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/core/apibara.ts
+++ b/packages/cli/src/core/apibara.ts
@@ -17,6 +17,11 @@ export async function createApibara(
 ): Promise<Apibara> {
   const options = await loadOptions(config, opts, dev);
 
+  // Enable source map support in Node
+  process.env.NODE_OPTIONS = process.env.NODE_OPTIONS
+    ? `${process.env.NODE_OPTIONS} --enable-source-maps`
+    : "--enable-source-maps";
+
   const apibara: Apibara = {
     options,
     indexers: [],

--- a/packages/cli/src/rolldown/config.ts
+++ b/packages/cli/src/rolldown/config.ts
@@ -20,7 +20,8 @@ const runtimeDependencies = [
   // https://socket.io/docs/v4/server-installation/#additional-packages
   "utf-8-validate",
   "bufferutil",
-  "node-fetch",
+  // was giving unresolved import warnings from `node-fetch` library.
+  "encoding",
 ];
 
 export function getRolldownConfig(apibara: Apibara): RolldownOptions {


### PR DESCRIPTION
- this enables support for source-maps, so error traces can be more readable.
- also replaces `node-fetch` with `encoding` in `runtimeDependencies`, as running build file like `dev.mjs` directly with `node` would throw errors for `node-fetch`.