### PR TITLE
cli: add `write-project-info` command to generate `project-info.json`

### DIFF
--- a/change/@apibara-beaconchain-adb65fa5-1af7-4e28-a28f-15ca24ee3129.json
+++ b/change/@apibara-beaconchain-adb65fa5-1af7-4e28-a28f-15ca24ee3129.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "protocol: add chain name to StreamConfig",
+  "packageName": "@apibara/beaconchain",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-evm-4523fa2d-787a-451e-95fd-5a478163f971.json
+++ b/change/@apibara-evm-4523fa2d-787a-451e-95fd-5a478163f971.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "protocol: add chain name to StreamConfig",
+  "packageName": "@apibara/evm",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-protocol-797f45f2-0d49-4e61-a606-13f653d35b9e.json
+++ b/change/@apibara-protocol-797f45f2-0d49-4e61-a606-13f653d35b9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "protocol: add chain name to StreamConfig",
+  "packageName": "@apibara/protocol",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-starknet-ba02e3e3-1803-4976-8c82-f375e7d2eeba.json
+++ b/change/@apibara-starknet-ba02e3e3-1803-4976-8c82-f375e7d2eeba.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "protocol: add chain name to StreamConfig",
+  "packageName": "@apibara/starknet",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/apibara-9e98cb09-3f83-4b64-94b0-f5b58209961e.json
+++ b/change/apibara-9e98cb09-3f83-4b64-94b0-f5b58209961e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "cli: add `write-project-info` command to generate `project-info.json`",
+  "packageName": "apibara",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/examples/cli-drizzle/apibara.config.ts
+++ b/examples/cli-drizzle/apibara.config.ts
@@ -9,4 +9,26 @@ export default defineConfig({
       startingBlock: 12_45_000,
     },
   },
+  presets: {
+    mainnet: {
+      runtimeConfig: {
+        evm: {
+          startingBlock: 215_30_000,
+        },
+        starknet: {
+          startingBlock: 12_45_000,
+        },
+      },
+    },
+    testnet: {
+      runtimeConfig: {
+        evm: {
+          startingBlock: 80_60_000,
+        },
+        starknet: {
+          startingBlock: 6_60_000,
+        },
+      },
+    },
+  },
 });

--- a/packages/beaconchain/src/index.ts
+++ b/packages/beaconchain/src/index.ts
@@ -12,4 +12,5 @@ export const BeaconChainStream = new StreamConfig(
   FilterFromBytes,
   BlockFromBytes,
   mergeFilter,
+  "beaconchain",
 );

--- a/packages/cli/src/cli/commands/write-project-info.ts
+++ b/packages/cli/src/cli/commands/write-project-info.ts
@@ -35,6 +35,8 @@ export default defineCommand({
         "project-info.mjs",
       ),
       "start",
+      "--build-dir",
+      apibara.options.buildDir,
     ];
 
     const child = spawn("node", childArgs, {
@@ -44,9 +46,11 @@ export default defineCommand({
     child.on("close", (code) => {
       if (code === 0) {
         consola.success("Project info written to `.apibara/project-info.json`");
-      } else {
-        consola.error("Failed to write project info");
       }
+    });
+
+    child.on("error", (error) => {
+      consola.error(`Failed to write project info: ${error.message}`, error);
     });
   },
 });

--- a/packages/cli/src/cli/commands/write-project-info.ts
+++ b/packages/cli/src/cli/commands/write-project-info.ts
@@ -1,0 +1,52 @@
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+import { build, createApibara, prepare, writeTypes } from "apibara/core";
+import { runtimeDir } from "apibara/runtime/meta";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { resolve } from "pathe";
+import { checkForUnknownArgs, commonArgs } from "../common";
+
+export default defineCommand({
+  meta: {
+    name: "write-project-info",
+    description: "Write json-encoded information about the project.",
+  },
+  args: {
+    ...commonArgs,
+  },
+  async run({ args, cmd }) {
+    await checkForUnknownArgs(args, cmd);
+
+    consola.start("Generating `project-info.json`");
+
+    const rootDir = resolve((args.dir || ".") as string);
+    const apibara = await createApibara({ rootDir, disableLogs: true });
+
+    apibara.options.entry = join(runtimeDir, "project-info.mjs");
+
+    await prepare(apibara);
+    await writeTypes(apibara);
+    await build(apibara);
+
+    const childArgs = [
+      resolve(
+        apibara.options.outputDir || "./.apibara/build",
+        "project-info.mjs",
+      ),
+      "start",
+    ];
+
+    const child = spawn("node", childArgs, {
+      stdio: "inherit",
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        consola.success("Project info written to `.apibara/project-info.json`");
+      } else {
+        consola.error("Failed to write project info");
+      }
+    });
+  },
+});

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -13,6 +13,8 @@ export const mainCli = defineCommand({
     prepare: () => import("./commands/prepare").then((r) => r.default),
     init: () => import("./commands/init").then((r) => r.default),
     add: () => import("./commands/add").then((r) => r.default),
+    "write-project-info": () =>
+      import("./commands/write-project-info").then((r) => r.default),
   },
 });
 

--- a/packages/cli/src/core/build/prepare.ts
+++ b/packages/cli/src/core/build/prepare.ts
@@ -7,9 +7,11 @@ export async function prepare(apibara: Apibara) {
   await prepareDir(apibara.options.buildDir);
   await prepareDir(apibara.options.outputDir);
 
-  apibara.logger.success(
-    `Output directory ${prettyPath(apibara.options.outputDir)} cleaned`,
-  );
+  if (!apibara.options.disableLogs) {
+    apibara.logger.success(
+      `Output directory ${prettyPath(apibara.options.outputDir)} cleaned`,
+    );
+  }
 }
 
 async function prepareDir(dir: string) {

--- a/packages/cli/src/core/build/prod.ts
+++ b/packages/cli/src/core/build/prod.ts
@@ -6,9 +6,11 @@ export async function buildProduction(
   apibara: Apibara,
   rolldownConfig: rolldown.RolldownOptions,
 ) {
-  apibara.logger.start(
-    `Building ${colors.cyan(apibara.indexers.length)} indexers`,
-  );
+  if (!apibara.options.disableLogs) {
+    apibara.logger.start(
+      `Building ${colors.cyan(apibara.indexers.length)} indexers`,
+    );
+  }
 
   const startTime = Date.now();
 
@@ -30,10 +32,12 @@ export async function buildProduction(
     const endTime = Date.now();
     const duration = endTime - startTime;
 
-    apibara.logger.success(`Build succeeded in ${duration}ms`);
-    apibara.logger.info(
-      `You can start the indexers with ${colors.cyan("apibara start")}`,
-    );
+    if (!apibara.options.disableLogs) {
+      apibara.logger.success(`Build succeeded in ${duration}ms`);
+      apibara.logger.info(
+        `You can start the indexers with ${colors.cyan("apibara start")}`,
+      );
+    }
   } catch (error) {
     apibara.logger.error("Build failed", error);
     throw error;

--- a/packages/cli/src/core/build/types.ts
+++ b/packages/cli/src/core/build/types.ts
@@ -55,5 +55,7 @@ declare module "apibara/types" {`,
     }),
   );
 
-  apibara.logger.success(`Types written to ${prettyPath(typesDir)}`);
+  if (!apibara.options.disableLogs) {
+    apibara.logger.success(`Types written to ${prettyPath(typesDir)}`);
+  }
 }

--- a/packages/cli/src/runtime/project-info.ts
+++ b/packages/cli/src/runtime/project-info.ts
@@ -20,8 +20,13 @@ const startCommand = defineCommand({
     name: "write-project-info",
     description: "Write json-encoded information about the project.",
   },
-  args: {},
-  async run() {
+  args: {
+    "build-dir": {
+      type: "string",
+      description: "project build directory",
+    },
+  },
+  async run({ args }) {
     const projectInfo: ProjectInfo = {
       indexers: {},
     };
@@ -44,8 +49,7 @@ const startCommand = defineCommand({
     }
 
     const projectInfoPath = resolve(
-      process.cwd(),
-      ".apibara",
+      args["build-dir"] ?? ".apibara",
       "project-info.json",
     );
 

--- a/packages/cli/src/runtime/project-info.ts
+++ b/packages/cli/src/runtime/project-info.ts
@@ -1,0 +1,68 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { defineCommand, runMain } from "citty";
+import { config } from "#apibara-internal-virtual/config";
+import { availableIndexers, createIndexer } from "./internal/app";
+
+type ProjectInfo = {
+  indexers: {
+    [indexerName: string]: {
+      [presetName: string]: {
+        type: string;
+        isFactory: boolean;
+      };
+    };
+  };
+};
+
+const startCommand = defineCommand({
+  meta: {
+    name: "write-project-info",
+    description: "Write json-encoded information about the project.",
+  },
+  args: {},
+  async run() {
+    const projectInfo: ProjectInfo = {
+      indexers: {},
+    };
+
+    for (const preset of Object.keys(config.presets ?? {})) {
+      for (const indexer of availableIndexers) {
+        const { indexer: indexerInstance } =
+          createIndexer(indexer, preset) ?? {};
+        if (!indexerInstance) {
+          continue;
+        }
+        projectInfo.indexers[indexer] = {
+          ...(projectInfo.indexers[indexer] ?? {}),
+          [preset]: {
+            type: indexerInstance.streamConfig.name,
+            isFactory: indexerInstance.options.factory !== undefined,
+          },
+        };
+      }
+    }
+
+    const projectInfoPath = resolve(
+      process.cwd(),
+      ".apibara",
+      "project-info.json",
+    );
+
+    writeFileSync(projectInfoPath, JSON.stringify(projectInfo, null, 2));
+  },
+});
+
+export const mainCli = defineCommand({
+  meta: {
+    name: "write-project-info-runner",
+    description: "Write json-encoded information about the project.",
+  },
+  subCommands: {
+    start: () => startCommand,
+  },
+});
+
+runMain(mainCli);
+
+export default {};

--- a/packages/cli/src/types/config.ts
+++ b/packages/cli/src/types/config.ts
@@ -75,6 +75,7 @@ export interface ApibaraOptions<
   buildDir: string;
   outputDir: string;
   indexersDir: string;
+  disableLogs?: boolean;
 
   // Dev
   dev: boolean;

--- a/packages/evm/src/index.ts
+++ b/packages/evm/src/index.ts
@@ -12,4 +12,5 @@ export const EvmStream = new StreamConfig(
   FilterFromBytes,
   BlockFromBytes,
   mergeFilter,
+  "evm",
 );

--- a/packages/protocol/src/config.ts
+++ b/packages/protocol/src/config.ts
@@ -10,6 +10,7 @@ export class StreamConfig<TFilter, TBlock> {
     private filter: Codec<TFilter, Uint8Array>,
     private block: Codec<TBlock | null, Uint8Array>,
     public mergeFilter: (a: TFilter, b: TFilter) => TFilter,
+    public name: string,
   ) {
     this.request = StreamDataRequest(this.filter);
     this.response = StreamDataResponse(this.block);

--- a/packages/protocol/src/testing/mock.ts
+++ b/packages/protocol/src/testing/mock.ts
@@ -61,6 +61,7 @@ export const MockStream = new StreamConfig(
   MockFilterFromBytes,
   MockBlockFromBytes,
   mergeMockFilter,
+  "mock",
 );
 
 export const MockStreamResponse = StreamDataResponse(MockBlockFromBytes);

--- a/packages/starknet/src/index.ts
+++ b/packages/starknet/src/index.ts
@@ -27,4 +27,5 @@ export const StarknetStream = new StreamConfig(
   FilterFromBytes,
   BlockFromBytes,
   mergeFilter,
+  "starknet",
 );


### PR DESCRIPTION
- updates `StreamConfig` class to accept chain name as argument, so all chain's name can be determined in runtime for metadata purpose from `Indexer` object. 
- adds a `write-project-info` command to cli, which creates `.apibara/project-info.json` with some metadata about indexers.