### PR TITLE
cli: fix live reload when indexer errors

### DIFF
--- a/change/apibara-935efd34-b737-4496-a67f-450a4f7caa7f.json
+++ b/change/apibara-935efd34-b737-4496-a67f-450a4f7caa7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "cli: fix live reload when indexer errors",
+  "packageName": "apibara",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/cli/commands/dev.ts
+++ b/packages/cli/src/cli/commands/dev.ts
@@ -138,6 +138,7 @@ export default defineCommand({
         });
 
         childProcess.on("close", (code, signal) => {
+          childProcess = undefined;
           console.log();
           apibara.logger.log(
             `Indexers process exited${


### PR DESCRIPTION
in `dev` mode, when there was an error in indexers, making changes would trigger reload but indexer wouldn't restart again, this fixes it.