### PR TITLE
Add byte array parser

### DIFF
--- a/change/@apibara-starknet-056a4593-d700-4325-aada-54b4af4cdd62.json
+++ b/change/@apibara-starknet-056a4593-d700-4325-aada-54b4af4cdd62.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "starknet: add ByteArray parser",
+  "packageName": "@apibara/starknet",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/packages/starknet/package.json
+++ b/packages/starknet/package.json
@@ -45,7 +45,6 @@
     "@apibara/protocol": "workspace:*",
     "@scure/starknet": "^1.1.0",
     "abi-wan-kanabi": "^2.2.4",
-    "effect": "^3.2.6",
     "long": "^5.2.1",
     "nice-grpc-common": "^2.0.2",
     "protobufjs": "^7.1.2"

--- a/packages/starknet/src/abi.ts
+++ b/packages/starknet/src/abi.ts
@@ -3,6 +3,7 @@ import { keccak } from "@scure/starknet";
 import type { FieldElement } from "./common";
 import {
   parseBool,
+  parseBytes31,
   parseContractAddress,
   parseFelt252,
   parseU8,
@@ -43,6 +44,7 @@ export const PrimitiveTypeParsers = {
   "core::integer::u64": parseU64,
   "core::integer::u128": parseU128,
   "core::integer::u256": parseU256,
+  "core::bytes_31::bytes31": parseBytes31,
   "core::starknet::contract_address::ContractAddress": parseContractAddress,
 };
 
@@ -76,4 +78,8 @@ export function getOptionType(type: string) {
 
 export function isEmptyType(type: string) {
   return type === "()";
+}
+
+export function isByteArray(type: string) {
+  return type === "core::byte_array::ByteArray";
 }

--- a/packages/starknet/src/event.ts
+++ b/packages/starknet/src/event.ts
@@ -10,6 +10,7 @@ import {
   getOptionType,
   getSpanType,
   isArrayType,
+  isByteArray,
   isEmptyType,
   isOptionType,
   isPrimitiveType,
@@ -30,6 +31,7 @@ import {
   ParseError,
   type Parser,
   parseArray,
+  parseByteArray,
   parseEmpty,
   parseOption,
   parseSpan,
@@ -296,6 +298,10 @@ function compileTypeParser(abi: Abi, type: string): Parser<unknown> {
 
   if (isEmptyType(type)) {
     return parseEmpty;
+  }
+
+  if (isByteArray(type)) {
+    return parseByteArray;
   }
 
   // Not a well-known type. Look it up in the ABI.

--- a/packages/starknet/tests/event.test.ts
+++ b/packages/starknet/tests/event.test.ts
@@ -7,6 +7,7 @@ import { getEventSelector } from "../src";
 import { chainlinkAbi } from "./fixtures/chainlink-abi";
 import { ekuboAbi } from "./fixtures/ekubo-abi";
 import { golifeAbi } from "./fixtures/golife-abi";
+import { paymentAbi } from "./fixtures/payment-abi";
 
 describe("decodeEvent", () => {
   describe("non strict mode", () => {
@@ -528,6 +529,74 @@ describe("decodeEvent", () => {
             "0x011f46882e19ad05d3762feda18b95af02b4d04ff264650de9665ede8f823262",
           ],
           "transactionHash": "0x02e0abd9a260095622f71ff8869aaee0267af1199be78ad5ad91a3c83df0ad08",
+          "transactionIndex": 0,
+          "transactionStatus": "succeeded",
+        }
+      `);
+    });
+
+    it("can decode PaymentReceived", () => {
+      const abi = paymentAbi;
+      const event = {
+        transactionHash:
+          "0x00c7b1db05a7d6e7edd6118f04de189db2353cb2484c6df7c191be1ef5af029c",
+        address:
+          "0x01f103e6694fcbdf2bfbe8db10d7b622bfab12da196ea1f212cb26367196af2c",
+        keys: [
+          "0x0040b634dd7cac6a7e5330478aa1704c7f20133def5f3fd107f3d185844a7b56",
+        ],
+        data: [
+          "0x2137b4260e19ab8beac7bcd8b006186ff855a3b257df8ebad346978972567fb",
+          "0x7d54bad6d6fcff799133a8c0b1fb8120876bb080d75cd601a5c68164d6f6d75",
+          "0xc8",
+          "0x0",
+          "0x0",
+          "0x7465737420726566",
+          "0x8",
+        ],
+        filterIds: [],
+        eventIndex: 0,
+        eventIndexInTransaction: 0,
+        transactionIndex: 0,
+        transactionStatus: "succeeded",
+      } as const satisfies Event;
+
+      const decoded = decodeEvent({
+        abi,
+        event,
+        eventName: "my_pay::contract::MyPay::Event",
+        strict: true,
+      });
+
+      expect(decoded).toMatchInlineSnapshot(`
+        {
+          "address": "0x01f103e6694fcbdf2bfbe8db10d7b622bfab12da196ea1f212cb26367196af2c",
+          "args": {
+            "PaymentReceived": {
+              "amount": 200n,
+              "reference": "0x7465737420726566",
+              "sender": "0x2137b4260e19ab8beac7bcd8b006186ff855a3b257df8ebad346978972567fb",
+              "token": "0x7d54bad6d6fcff799133a8c0b1fb8120876bb080d75cd601a5c68164d6f6d75",
+            },
+            "_tag": "PaymentReceived",
+          },
+          "data": [
+            "0x2137b4260e19ab8beac7bcd8b006186ff855a3b257df8ebad346978972567fb",
+            "0x7d54bad6d6fcff799133a8c0b1fb8120876bb080d75cd601a5c68164d6f6d75",
+            "0xc8",
+            "0x0",
+            "0x0",
+            "0x7465737420726566",
+            "0x8",
+          ],
+          "eventIndex": 0,
+          "eventIndexInTransaction": 0,
+          "eventName": "my_pay::contract::MyPay::Event",
+          "filterIds": [],
+          "keys": [
+            "0x0040b634dd7cac6a7e5330478aa1704c7f20133def5f3fd107f3d185844a7b56",
+          ],
+          "transactionHash": "0x00c7b1db05a7d6e7edd6118f04de189db2353cb2484c6df7c191be1ef5af029c",
           "transactionIndex": 0,
           "transactionStatus": "succeeded",
         }

--- a/packages/starknet/tests/fixtures/payment-abi.ts
+++ b/packages/starknet/tests/fixtures/payment-abi.ts
@@ -1,0 +1,123 @@
+import type { Abi } from "../../src/index";
+
+export const paymentAbi = [
+  {
+    name: "core::integer::u256",
+    type: "struct",
+    members: [
+      {
+        name: "low",
+        type: "core::integer::u128",
+      },
+      {
+        name: "high",
+        type: "core::integer::u128",
+      },
+    ],
+  },
+  {
+    name: "core::byte_array::ByteArray",
+    type: "struct",
+    members: [
+      {
+        name: "data",
+        type: "core::array::Array::<core::bytes_31::bytes31>",
+      },
+      {
+        name: "pending_word",
+        type: "core::felt252",
+      },
+      {
+        name: "pending_word_len",
+        type: "core::integer::u32",
+      },
+    ],
+  },
+  {
+    name: "core::bool",
+    type: "enum",
+    variants: [
+      {
+        name: "False",
+        type: "()",
+      },
+      {
+        name: "True",
+        type: "()",
+      },
+    ],
+  },
+  {
+    kind: "struct",
+    name: "my_pay::contract::MyPay::TokenAdded",
+    type: "event",
+    members: [
+      {
+        kind: "data",
+        name: "token",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+  },
+  {
+    kind: "struct",
+    name: "my_pay::contract::MyPay::TokenRemoved",
+    type: "event",
+    members: [
+      {
+        kind: "data",
+        name: "token",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+  },
+  {
+    kind: "struct",
+    name: "my_pay::contract::MyPay::PaymentReceived",
+    type: "event",
+    members: [
+      {
+        kind: "data",
+        name: "sender",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        kind: "data",
+        name: "token",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        kind: "data",
+        name: "amount",
+        type: "core::integer::u256",
+      },
+      {
+        kind: "data",
+        name: "reference",
+        type: "core::byte_array::ByteArray",
+      },
+    ],
+  },
+  {
+    kind: "enum",
+    name: "my_pay::contract::MyPay::Event",
+    type: "event",
+    variants: [
+      {
+        kind: "nested",
+        name: "TokenAdded",
+        type: "my_pay::contract::MyPay::TokenAdded",
+      },
+      {
+        kind: "nested",
+        name: "TokenRemoved",
+        type: "my_pay::contract::MyPay::TokenRemoved",
+      },
+      {
+        kind: "nested",
+        name: "PaymentReceived",
+        type: "my_pay::contract::MyPay::PaymentReceived",
+      },
+    ],
+  },
+] as const satisfies Abi;

--- a/packages/starknet/tests/parser.test.ts
+++ b/packages/starknet/tests/parser.test.ts
@@ -5,6 +5,7 @@ import {
   parseArray,
   parseAsHex,
   parseBool,
+  parseByteArray,
   parseFelt252,
   parseOption,
   parseStruct,
@@ -165,5 +166,46 @@ describe("Tuple parser", () => {
     )(data, 0);
     expect(out).toEqual([1n, [2n, 3n], false]);
     expect(offset).toBe(4);
+  });
+});
+
+describe("ByteArray parser", () => {
+  it("can parse an empty byte array", () => {
+    const data = ["0x0", "0x0", "0x0"] as const;
+    const { out, offset } = parseByteArray(data, 0);
+    expect(out).toEqual("0x00");
+    expect(offset).toBe(3);
+  });
+
+  it("can parse a byte array with empty data", () => {
+    const data = ["0x0", "0x465737420726566", "0x8"] as const;
+    const { out, offset } = parseByteArray(data, 0);
+    expect(out).toEqual("0x0465737420726566");
+    expect(offset).toBe(3);
+  });
+
+  it("can parse a byte array with pending data starting with zero", () => {
+    const data = ["0x0", "0x465737420726566", "0xa"] as const;
+    const { out, offset } = parseByteArray(data, 0);
+    expect(out).toEqual("0x0465737420726566");
+    expect(offset).toBe(3);
+  });
+
+  it("can parse a byte array data and no pending data", () => {
+    const data = ["0x2", "0xa", "0x07", "0x0", "0x0"] as const;
+    const { out, offset } = parseByteArray(data, 0);
+    expect(out).toEqual(
+      "0x0a00000000000000000000000000000000000000000000000000000000000007",
+    );
+    expect(offset).toBe(5);
+  });
+
+  it("can parse a byte array data and pending data", () => {
+    const data = ["0x2", "0xa", "0x07", "0x7465737420726566", "0xa"] as const;
+    const { out, offset } = parseByteArray(data, 0);
+    expect(out).toEqual(
+      "0x0a0000000000000000000000000000000000000000000000000000000000000700007465737420726566",
+    );
+    expect(offset).toBe(5);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,9 +620,6 @@ importers:
       abi-wan-kanabi:
         specifier: ^2.2.4
         version: 2.2.4
-      effect:
-        specifier: ^3.2.6
-        version: 3.2.6
       long:
         specifier: ^5.2.1
         version: 5.2.3


### PR DESCRIPTION
I changed the event decoder to parse byte arrays into bytes, represented as `0x${string}`.
