### PR TITLE
starknet: fix enum handling and types in event decoder

### DIFF
--- a/change/@apibara-starknet-2fb40364-ed44-45a8-b402-3a014057aa82.json
+++ b/change/@apibara-starknet-2fb40364-ed44-45a8-b402-3a014057aa82.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "starknet: fix enum handling and types in eventDecoder",
+  "packageName": "@apibara/starknet",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/starknet/tests/event.test.ts
+++ b/packages/starknet/tests/event.test.ts
@@ -8,6 +8,7 @@ import { chainlinkAbi } from "./fixtures/chainlink-abi";
 import { ekuboAbi } from "./fixtures/ekubo-abi";
 import { golifeAbi } from "./fixtures/golife-abi";
 import { paymentAbi } from "./fixtures/payment-abi";
+import { registryAbi } from "./fixtures/registry-abi";
 
 describe("decodeEvent", () => {
   describe("non strict mode", () => {
@@ -667,6 +668,68 @@ describe("decodeEvent", () => {
       });
 
       expect(decoded).toBeNull();
+    });
+
+    it('can decode event with nested enum with null ["()" type] data', () => {
+      const abi = registryAbi;
+      const userRegisteredEventSelector = getEventSelector("UserRegistered");
+
+      const event = {
+        transactionHash:
+          "0x07c2ea2b2211421e1a74e25f9fe9ad36862c83d6b7189b91185496c41cd83fc9",
+        address:
+          "0x04319b2cdf8f484e965a7df709e75c4d5c89780d3601f5105e1bc26243dd45b6",
+        keys: [
+          userRegisteredEventSelector,
+          "0x348ed741a6cfdfa876b4bc233e8f769468a624ae66543d610235112943cc993",
+          "0x796f64613133",
+        ],
+        data: ["0x6877a1fd", "0x1"],
+        filterIds: [],
+        eventIndex: 0,
+        eventIndexInTransaction: 0,
+        transactionIndex: 0,
+        transactionStatus: "succeeded",
+      } as const satisfies Event;
+
+      const decoded = decodeEvent({
+        abi,
+        event,
+        eventName:
+          "opinion_competitions::utils::common::events::UserRegistered",
+        strict: true,
+      });
+
+      expect(decoded).toMatchInlineSnapshot(`
+        {
+          "address": "0x04319b2cdf8f484e965a7df709e75c4d5c89780d3601f5105e1bc26243dd45b6",
+          "args": {
+            "timestamp": 1752670717n,
+            "user": "0x348ed741a6cfdfa876b4bc233e8f769468a624ae66543d610235112943cc993",
+            "username": 133519332421939n,
+            "verification_level": {
+              "ORB": null,
+              "_tag": "ORB",
+            },
+          },
+          "data": [
+            "0x6877a1fd",
+            "0x1",
+          ],
+          "eventIndex": 0,
+          "eventIndexInTransaction": 0,
+          "eventName": "opinion_competitions::utils::common::events::UserRegistered",
+          "filterIds": [],
+          "keys": [
+            "0x015854d06e396351cf7ea2143ce9ba79f24588d0f1b1617f54e9acca7a6ac325",
+            "0x348ed741a6cfdfa876b4bc233e8f769468a624ae66543d610235112943cc993",
+            "0x796f64613133",
+          ],
+          "transactionHash": "0x07c2ea2b2211421e1a74e25f9fe9ad36862c83d6b7189b91185496c41cd83fc9",
+          "transactionIndex": 0,
+          "transactionStatus": "succeeded",
+        }
+      `);
     });
   });
 });

--- a/packages/starknet/tests/fixtures/registry-abi.ts
+++ b/packages/starknet/tests/fixtures/registry-abi.ts
@@ -1,0 +1,416 @@
+import type { Abi } from "../../src/index";
+
+export const registryAbi = [
+  {
+    name: "IOlasCompetitionsRegistry",
+    type: "impl",
+    interface_name:
+      "opinion_competitions::interfaces::IOlasCompetitionRegistry::IOlasCompetitionRegistry",
+  },
+  {
+    name: "core::array::Span::<core::felt252>",
+    type: "struct",
+    members: [
+      {
+        name: "snapshot",
+        type: "@core::array::Array::<core::felt252>",
+      },
+    ],
+  },
+  {
+    name: "core::option::Option::<core::array::Span::<core::felt252>>",
+    type: "enum",
+    variants: [
+      {
+        name: "Some",
+        type: "core::array::Span::<core::felt252>",
+      },
+      {
+        name: "None",
+        type: "()",
+      },
+    ],
+  },
+  {
+    name: "core::bool",
+    type: "enum",
+    variants: [
+      {
+        name: "False",
+        type: "()",
+      },
+      {
+        name: "True",
+        type: "()",
+      },
+    ],
+  },
+  {
+    name: "opinion_competitions::utils::common::enums::VerificationLevel",
+    type: "enum",
+    variants: [
+      {
+        name: "UNVERIFIED",
+        type: "()",
+      },
+      {
+        name: "ORB",
+        type: "()",
+      },
+      {
+        name: "DEVICE",
+        type: "()",
+      },
+    ],
+  },
+  {
+    name: "opinion_competitions::utils::common::structs::RegistryDetails",
+    type: "struct",
+    members: [
+      {
+        name: "is_registered",
+        type: "core::bool",
+      },
+      {
+        name: "username",
+        type: "core::felt252",
+      },
+      {
+        name: "verification_level",
+        type: "opinion_competitions::utils::common::enums::VerificationLevel",
+      },
+      {
+        name: "is_admin_verified",
+        type: "core::bool",
+      },
+    ],
+  },
+  {
+    name: "core::integer::u256",
+    type: "struct",
+    members: [
+      {
+        name: "low",
+        type: "core::integer::u128",
+      },
+      {
+        name: "high",
+        type: "core::integer::u128",
+      },
+    ],
+  },
+  {
+    name: "opinion_competitions::interfaces::IOlasCompetitionRegistry::IOlasCompetitionRegistry",
+    type: "interface",
+    items: [
+      {
+        name: "register_user",
+        type: "function",
+        inputs: [
+          {
+            name: "user_address",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "username",
+            type: "core::felt252",
+          },
+          {
+            name: "full_proof_with_hints",
+            type: "core::option::Option::<core::array::Span::<core::felt252>>",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "external",
+      },
+      {
+        name: "mark_user_as_device_verified",
+        type: "function",
+        inputs: [
+          {
+            name: "user_address",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "external",
+      },
+      {
+        name: "update_admin",
+        type: "function",
+        inputs: [
+          {
+            name: "new_admin",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "external",
+      },
+      {
+        name: "update_trusted_entities",
+        type: "function",
+        inputs: [
+          {
+            name: "entity",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "is_trusted",
+            type: "core::bool",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "external",
+      },
+      {
+        name: "use_voting_power",
+        type: "function",
+        inputs: [
+          {
+            name: "user",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "amount",
+            type: "core::integer::u128",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::integer::u128",
+          },
+        ],
+        state_mutability: "external",
+      },
+      {
+        name: "add_voting_power",
+        type: "function",
+        inputs: [
+          {
+            name: "user",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "amount",
+            type: "core::integer::u128",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::integer::u128",
+          },
+        ],
+        state_mutability: "external",
+      },
+      {
+        name: "get_user_details",
+        type: "function",
+        inputs: [
+          {
+            name: "user",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [
+          {
+            type: "opinion_competitions::utils::common::structs::RegistryDetails",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "is_nullifier_used",
+        type: "function",
+        inputs: [
+          {
+            name: "nullifier_hash",
+            type: "core::integer::u256",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "is_trusted_entity",
+        type: "function",
+        inputs: [
+          {
+            name: "entity",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "is_username_taken",
+        type: "function",
+        inputs: [
+          {
+            name: "username",
+            type: "core::felt252",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "get_initial_voting_power",
+        type: "function",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::integer::u128",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "get_voting_power",
+        type: "function",
+        inputs: [
+          {
+            name: "user",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::integer::u128",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "world_bridge_address",
+        type: "function",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        name: "registry_admin",
+        type: "function",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        state_mutability: "view",
+      },
+    ],
+  },
+  {
+    name: "constructor",
+    type: "constructor",
+    inputs: [
+      {
+        name: "bridge",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        name: "initial_voting_power",
+        type: "core::integer::u128",
+      },
+      {
+        name: "admin",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+  },
+  {
+    kind: "struct",
+    name: "opinion_competitions::utils::common::events::UserRegistered",
+    type: "event",
+    members: [
+      {
+        kind: "key",
+        name: "user",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        kind: "key",
+        name: "username",
+        type: "core::felt252",
+      },
+      {
+        kind: "data",
+        name: "timestamp",
+        type: "core::integer::u64",
+      },
+      {
+        kind: "data",
+        name: "verification_level",
+        type: "opinion_competitions::utils::common::enums::VerificationLevel",
+      },
+    ],
+  },
+  {
+    kind: "struct",
+    name: "opinion_competitions::utils::common::events::AdminUpdated",
+    type: "event",
+    members: [
+      {
+        kind: "data",
+        name: "prev_admin",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        kind: "data",
+        name: "new_admin",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+  },
+  {
+    kind: "enum",
+    name: "opinion_competitions::contracts::OlasCompetitionsRegistry::OlasCompetitionsRegistry::Event",
+    type: "event",
+    variants: [
+      {
+        kind: "nested",
+        name: "UserRegistered",
+        type: "opinion_competitions::utils::common::events::UserRegistered",
+      },
+      {
+        kind: "nested",
+        name: "AdminUpdated",
+        type: "opinion_competitions::utils::common::events::AdminUpdated",
+      },
+    ],
+  },
+] as const satisfies Abi;


### PR DESCRIPTION
fixes an issue where event decoder `decodeEvent()` would throw error in case of nested enums parsing. also overrides a `abi-wan-kanabi` type to improve type safety for enum types and match with our own runtime values. 