### PR TITLE
fix: retry UNAVAILABLE and other transient gRPC errors in runWithReconnect

### DIFF
--- a/change/@apibara-indexer-046e66a2-9fc8-40b0-9b2c-85296d232251.json
+++ b/change/@apibara-indexer-046e66a2-9fc8-40b0-9b2c-85296d232251.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: retry UNAVAILABLE and other transient gRPC errors in runWithReconnect",
+  "packageName": "@apibara/indexer",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/packages/indexer/src/indexer.ts
+++ b/packages/indexer/src/indexer.ts
@@ -227,10 +227,17 @@ export async function runWithReconnect<TFilter, TBlock>(
       if (error instanceof ClientError || error instanceof ServerError) {
         const isServerError = error instanceof ServerError;
 
-        if (error.code === Status.INTERNAL) {
+        const retryableCodes = [
+          Status.INTERNAL,
+          Status.UNAVAILABLE,
+          Status.DEADLINE_EXCEEDED,
+          Status.RESOURCE_EXHAUSTED,
+        ];
+
+        if (retryableCodes.includes(error.code)) {
           if (retryCount < maxRetries) {
             consola.error(
-              `Internal ${isServerError ? "server" : "client"} error: ${
+              `Transient ${isServerError ? "server" : "client"} error: ${
                 error.message
               }`,
             );


### PR DESCRIPTION
## Problem

`runWithReconnect()` in `packages/indexer/src/indexer.ts` only retries errors with `Status.INTERNAL`. When a gRPC stream experiences a TCP connection reset (`ECONNRESET`), `nice-grpc` wraps it as a `ClientError` with `Status.UNAVAILABLE`. Since `UNAVAILABLE` is not in the retry condition, the error is immediately re-thrown and the indexer process crashes.

This is the most common transient failure mode in production — the DNA stream server drops long-lived gRPC connections due to network transience, idle timeouts, load balancer resets, or server restarts.

## Error

```
[error] /dna.v2.stream.DnaStream/StreamData UNAVAILABLE: read ECONNRESET
  at wrapClientError (node_modules/nice-grpc/lib/client/wrapClientError.js:9:16)
  at serverStreamingMethod (node_modules/nice-grpc/lib/client/createServerStreamingMethod.js:41:41)
```

## Fix

Add `UNAVAILABLE`, `DEADLINE_EXCEEDED`, and `RESOURCE_EXHAUSTED` to the retryable status codes, matching [Google's gRPC retry guidance](https://grpc.io/docs/guides/retry/) which lists `UNAVAILABLE` as the primary retryable status code.

```typescript
const retryableCodes = [
  Status.INTERNAL,
  Status.UNAVAILABLE,
  Status.DEADLINE_EXCEEDED,
  Status.RESOURCE_EXHAUSTED,
];

if (retryableCodes.includes(error.code)) {
```

## What changed

- `packages/indexer/src/indexer.ts`: One condition expanded from `error.code === Status.INTERNAL` to `retryableCodes.includes(error.code)` with the 4 transient gRPC status codes
- Log message changed from "Internal" to "Transient" to reflect the broader scope

The diff is minimal — 1 file, 9 insertions, 2 deletions.