### PR TITLE
Add Starknet RPC event indexing package

### DIFF
--- a/change/@apibara-indexer-rpc-stream-config.json
+++ b/change/@apibara-indexer-rpc-stream-config.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow indexers to use RPC stream configs",
+  "packageName": "@apibara/indexer",
+  "email": "loothero@provable.games",
+  "dependentChangeType": "patch"
+}

--- a/change/@apibara-starknet-rpc-4bb3abe9-7bf6-4477-add1-8177352f12ee.json
+++ b/change/@apibara-starknet-rpc-4bb3abe9-7bf6-4477-add1-8177352f12ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Starknet RPC event helpers",
+  "packageName": "@apibara/starknet-rpc",
+  "email": "loothero@provable.games",
+  "dependentChangeType": "patch"
+}

--- a/change/apibara-rpc-stream-runtime-client.json
+++ b/change/apibara-rpc-stream-runtime-client.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Support RPC stream configs in the CLI runtime",
+  "packageName": "apibara",
+  "email": "loothero@provable.games",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/runtime/dev.ts
+++ b/packages/cli/src/runtime/dev.ts
@@ -1,10 +1,10 @@
 import { ReloadIndexerRequest, runWithReconnect } from "@apibara/indexer";
-import { createAuthenticatedClient } from "@apibara/protocol";
 import { getRuntimeDataFromEnv } from "apibara/common";
 import { defineCommand, runMain } from "citty";
 import type { ConsolaInstance } from "consola";
 import { blueBright } from "picocolors";
 import { availableIndexers, createIndexer } from "./internal/app";
+import { createRuntimeClient } from "./internal/client";
 
 async function startIndexer(indexer: string, signal: AbortSignal) {
   let _logger: ConsolaInstance | undefined;
@@ -25,11 +25,11 @@ async function startIndexer(indexer: string, signal: AbortSignal) {
         return;
       }
 
-      const client = createAuthenticatedClient(
-        indexerInstance.streamConfig,
-        indexerInstance.options.streamUrl,
-        indexerInstance.options.clientOptions,
-      );
+      const client = createRuntimeClient({
+        streamConfig: indexerInstance.streamConfig,
+        streamUrl: indexerInstance.options.streamUrl,
+        clientOptions: indexerInstance.options.clientOptions,
+      });
 
       if (logger) {
         logger.info(`Indexer ${blueBright(indexer)} started`);

--- a/packages/cli/src/runtime/internal/client.ts
+++ b/packages/cli/src/runtime/internal/client.ts
@@ -1,0 +1,27 @@
+import type { IndexerStreamConfig } from "@apibara/indexer";
+import {
+  type Client,
+  type CreateClientOptions,
+  createAuthenticatedClient,
+} from "@apibara/protocol";
+import { createRpcClient } from "@apibara/protocol/rpc";
+
+export function createRuntimeClient<TFilter, TBlock>({
+  streamConfig,
+  streamUrl,
+  clientOptions,
+}: {
+  streamConfig: IndexerStreamConfig<TFilter, TBlock>;
+  streamUrl?: string;
+  clientOptions?: CreateClientOptions;
+}): Client<TFilter, TBlock> {
+  if ("Request" in streamConfig) {
+    if (!streamUrl) {
+      throw new Error("streamUrl is required when using a DNA StreamConfig");
+    }
+
+    return createAuthenticatedClient(streamConfig, streamUrl, clientOptions);
+  }
+
+  return createRpcClient(streamConfig);
+}

--- a/packages/cli/src/runtime/project-info.ts
+++ b/packages/cli/src/runtime/project-info.ts
@@ -59,7 +59,7 @@ const startCommand = defineCommand({
         projectInfo.indexers[indexer] = {
           ...(projectInfo.indexers[indexer] ?? {}),
           [preset]: {
-            type: indexerInstance.streamConfig.name,
+            type: streamConfigType(indexerInstance.streamConfig),
             isFactory: indexerInstance.options.factory !== undefined,
           },
         };
@@ -74,6 +74,29 @@ const startCommand = defineCommand({
     writeFileSync(projectInfoPath, JSON.stringify(projectInfo, null, 2));
   },
 });
+
+function streamConfigType(streamConfig: unknown): string {
+  if (
+    typeof streamConfig === "object" &&
+    streamConfig !== null &&
+    "name" in streamConfig &&
+    typeof streamConfig.name === "string"
+  ) {
+    return streamConfig.name;
+  }
+
+  if (
+    typeof streamConfig === "object" &&
+    streamConfig !== null &&
+    "constructor" in streamConfig &&
+    typeof streamConfig.constructor === "function" &&
+    streamConfig.constructor.name
+  ) {
+    return streamConfig.constructor.name;
+  }
+
+  return "RpcStreamConfig";
+}
 
 export const mainCli = defineCommand({
   meta: {

--- a/packages/cli/src/runtime/start.ts
+++ b/packages/cli/src/runtime/start.ts
@@ -1,5 +1,4 @@
 import { ReloadIndexerRequest, runWithReconnect } from "@apibara/indexer";
-import { createAuthenticatedClient } from "@apibara/protocol";
 import {
   checkForUnknownArgs,
   getProcessedRuntimeConfig,
@@ -17,6 +16,7 @@ import {
   userEnvRuntimeConfig,
 } from "#apibara-internal-virtual/static-config";
 import { createIndexer } from "./internal/app";
+import { createRuntimeClient } from "./internal/client";
 
 const startCommand = defineCommand({
   meta: {
@@ -83,11 +83,11 @@ const startCommand = defineCommand({
           process.exit(1);
         }
 
-        const client = createAuthenticatedClient(
-          indexerInstance.streamConfig,
-          indexerInstance.options.streamUrl,
-          indexerInstance.options.clientOptions,
-        );
+        const client = createRuntimeClient({
+          streamConfig: indexerInstance.streamConfig,
+          streamUrl: indexerInstance.options.streamUrl,
+          clientOptions: indexerInstance.options.clientOptions,
+        });
 
         if (register) {
           consola.start("Registering from instrumentation");

--- a/packages/indexer/src/indexer.ts
+++ b/packages/indexer/src/indexer.ts
@@ -117,8 +117,7 @@ export type HandlerArgs<TBlock> = {
   abortSignal?: AbortSignal;
 };
 
-export type IndexerConfig<TFilter, TBlock> = {
-  streamUrl?: string;
+export type BaseIndexerConfig<TFilter, TBlock> = {
   filter: TFilter;
   finality?: DataFinality;
   clientOptions?: CreateClientOptions;
@@ -131,35 +130,60 @@ export type IndexerConfig<TFilter, TBlock> = {
   debug?: boolean;
 } & IndexerStartingCursor;
 
+export type IndexerConfig<TFilter, TBlock> = BaseIndexerConfig<
+  TFilter,
+  TBlock
+> & {
+  streamUrl: string;
+};
+
+export type RpcIndexerConfig<TFilter, TBlock> = BaseIndexerConfig<
+  TFilter,
+  TBlock
+> & {
+  streamUrl?: string;
+};
+
 export type IndexerStreamConfig<TFilter, TBlock> =
   | StreamConfig<TFilter, TBlock>
   | RpcStreamConfig<TFilter, TBlock>;
 
-export type IndexerWithStreamConfig<TFilter, TBlock> = IndexerConfig<
+export type IndexerWithDnaStreamConfig<TFilter, TBlock> = IndexerConfig<
   TFilter,
   TBlock
 > & {
-  streamConfig: IndexerStreamConfig<TFilter, TBlock>;
+  streamConfig: StreamConfig<TFilter, TBlock>;
 };
+
+export type IndexerWithRpcStreamConfig<TFilter, TBlock> = RpcIndexerConfig<
+  TFilter,
+  TBlock
+> & {
+  streamConfig: RpcStreamConfig<TFilter, TBlock>;
+};
+
+export type IndexerWithStreamConfig<TFilter, TBlock> =
+  | IndexerWithDnaStreamConfig<TFilter, TBlock>
+  | IndexerWithRpcStreamConfig<TFilter, TBlock>;
 
 export function defineIndexer<TFilter, TBlock>(
   streamConfig: StreamConfig<TFilter, TBlock>,
 ): (
-  config: IndexerConfig<TFilter, TBlock> & { streamUrl: string },
-) => IndexerWithStreamConfig<TFilter, TBlock>;
+  config: IndexerConfig<TFilter, TBlock>,
+) => IndexerWithDnaStreamConfig<TFilter, TBlock>;
 
 export function defineIndexer<TFilter, TBlock>(
   streamConfig: RpcStreamConfig<TFilter, TBlock>,
 ): (
-  config: IndexerConfig<TFilter, TBlock>,
-) => IndexerWithStreamConfig<TFilter, TBlock>;
+  config: RpcIndexerConfig<TFilter, TBlock>,
+) => IndexerWithRpcStreamConfig<TFilter, TBlock>;
 
 export function defineIndexer<TFilter, TBlock>(
   streamConfig: IndexerStreamConfig<TFilter, TBlock>,
-) {
+): unknown {
   return (
-    config: IndexerConfig<TFilter, TBlock>,
-  ): IndexerWithStreamConfig<TFilter, TBlock> => ({
+    config: IndexerConfig<TFilter, TBlock> | RpcIndexerConfig<TFilter, TBlock>,
+  ) => ({
     streamConfig,
     ...config,
   });
@@ -167,7 +191,7 @@ export function defineIndexer<TFilter, TBlock>(
 
 export interface Indexer<TFilter, TBlock> {
   streamConfig: IndexerStreamConfig<TFilter, TBlock>;
-  options: IndexerConfig<TFilter, TBlock>;
+  options: IndexerConfig<TFilter, TBlock> | RpcIndexerConfig<TFilter, TBlock>;
   hooks: Hookable<IndexerHooks<TFilter, TBlock>>;
 }
 

--- a/packages/indexer/src/indexer.ts
+++ b/packages/indexer/src/indexer.ts
@@ -15,6 +15,7 @@ import {
   type StreamDataResponse,
   type SystemMessage,
 } from "@apibara/protocol";
+import type { RpcStreamConfig } from "@apibara/protocol/rpc";
 import consola from "consola";
 import {
   type Hookable,
@@ -117,7 +118,7 @@ export type HandlerArgs<TBlock> = {
 };
 
 export type IndexerConfig<TFilter, TBlock> = {
-  streamUrl: string;
+  streamUrl?: string;
   filter: TFilter;
   finality?: DataFinality;
   clientOptions?: CreateClientOptions;
@@ -130,15 +131,31 @@ export type IndexerConfig<TFilter, TBlock> = {
   debug?: boolean;
 } & IndexerStartingCursor;
 
+export type IndexerStreamConfig<TFilter, TBlock> =
+  | StreamConfig<TFilter, TBlock>
+  | RpcStreamConfig<TFilter, TBlock>;
+
 export type IndexerWithStreamConfig<TFilter, TBlock> = IndexerConfig<
   TFilter,
   TBlock
 > & {
-  streamConfig: StreamConfig<TFilter, TBlock>;
+  streamConfig: IndexerStreamConfig<TFilter, TBlock>;
 };
 
 export function defineIndexer<TFilter, TBlock>(
   streamConfig: StreamConfig<TFilter, TBlock>,
+): (
+  config: IndexerConfig<TFilter, TBlock> & { streamUrl: string },
+) => IndexerWithStreamConfig<TFilter, TBlock>;
+
+export function defineIndexer<TFilter, TBlock>(
+  streamConfig: RpcStreamConfig<TFilter, TBlock>,
+): (
+  config: IndexerConfig<TFilter, TBlock>,
+) => IndexerWithStreamConfig<TFilter, TBlock>;
+
+export function defineIndexer<TFilter, TBlock>(
+  streamConfig: IndexerStreamConfig<TFilter, TBlock>,
 ) {
   return (
     config: IndexerConfig<TFilter, TBlock>,
@@ -149,7 +166,7 @@ export function defineIndexer<TFilter, TBlock>(
 }
 
 export interface Indexer<TFilter, TBlock> {
-  streamConfig: StreamConfig<TFilter, TBlock>;
+  streamConfig: IndexerStreamConfig<TFilter, TBlock>;
   options: IndexerConfig<TFilter, TBlock>;
   hooks: Hookable<IndexerHooks<TFilter, TBlock>>;
 }
@@ -175,6 +192,20 @@ export function createIndexer<TFilter, TBlock>({
   }
 
   return indexer;
+}
+
+function mergeFilterWithStreamConfig<TFilter, TBlock>(
+  streamConfig: IndexerStreamConfig<TFilter, TBlock>,
+  a: TFilter,
+  b: TFilter,
+): TFilter {
+  if ("mergeFilter" in streamConfig) {
+    return streamConfig.mergeFilter(a, b);
+  }
+
+  throw new Error(
+    "Factory mode requires a stream config with mergeFilter support.",
+  );
 }
 
 export interface ReconnectOptions {
@@ -434,7 +465,8 @@ export async function run<TFilter, TBlock>(
                   if (filter) {
                     // when filter is defined
                     // merge old and new filters
-                    mainFilter = indexer.streamConfig.mergeFilter(
+                    mainFilter = mergeFilterWithStreamConfig(
+                      indexer.streamConfig,
                       mainFilter,
                       filter,
                     );

--- a/packages/indexer/src/testing/index.ts
+++ b/packages/indexer/src/testing/index.ts
@@ -67,6 +67,14 @@ export function createVcr() {
           throw new Error("Cannot record cassette in CI");
         }
 
+        if (!("Request" in indexer.streamConfig)) {
+          throw new Error("VCR recording requires a DNA StreamConfig");
+        }
+
+        if (!indexer.options.streamUrl) {
+          throw new Error("VCR recording requires streamUrl");
+        }
+
         const client = createAuthenticatedClient(
           indexer.streamConfig,
           indexer.options.streamUrl,

--- a/packages/starknet-rpc/README.md
+++ b/packages/starknet-rpc/README.md
@@ -51,6 +51,8 @@ for await (const message of backfillEvents({
 
 `cursor` means "last successfully persisted event". When a cursor is supplied,
 the backfill starts from that block and skips events at or before the cursor.
+Reorg handling should persist `message.rollbackCursor`; that cursor sorts before
+the first event in the rollback block.
 
 ## Live Subscription
 
@@ -67,7 +69,10 @@ const subscription = subscribeEvents({
 try {
   for await (const message of subscription) {
     if (message.type === "reorg") {
-      await rollbackFrom(message.reorg.startingBlockNumber);
+      await db.transaction(async (tx) => {
+        await rollbackFrom(tx, message.reorg.startingBlockNumber);
+        await saveCursor(tx, message.rollbackCursor);
+      });
       continue;
     }
 
@@ -96,7 +101,10 @@ for await (const message of streamEvents({
   keys: [["0xabcdef"]],
 })) {
   if (message.type === "reorg") {
-    await rollbackFrom(message.reorg.startingBlockNumber);
+    await db.transaction(async (tx) => {
+      await rollbackFrom(tx, message.reorg.startingBlockNumber);
+      await saveCursor(tx, message.rollbackCursor);
+    });
     continue;
   }
 
@@ -181,8 +189,26 @@ On a reorg message, roll back all chain-derived rows where:
 block_number >= starting_block_number
 ```
 
+Update the persisted cursor to `message.rollbackCursor` in the same transaction
+as the chain-row rollback:
+
+```ts
+await db.transaction(async (tx) => {
+  await tx.sql`
+    delete from indexed_events
+    where block_number >= ${message.reorg.startingBlockNumber}
+  `;
+
+  await saveCursor(tx, message.rollbackCursor);
+});
+```
+
 After the caller handles the rollback, `streamEvents` resumes from the reorg
 starting block with HTTP backfill and then returns to WebSocket live indexing.
+If a process restarts with a persisted pre-confirmed cursor beyond the current
+accepted head, `streamEvents` emits a synthetic reorg message and resets its
+dedupe state to `message.rollbackCursor` before subscribing live. This prevents
+replacement events at the same cursor ordering from being skipped.
 
 ## Finality
 

--- a/packages/starknet-rpc/README.md
+++ b/packages/starknet-rpc/README.md
@@ -97,6 +97,7 @@ for await (const message of streamEvents({
   wsUrl: process.env.STARKNET_WS_URL!,
   fromBlock: { block_number: 0 },
   cursor: await loadCursor(),
+  cursorFinalityStatus: await loadCursorFinalityStatus(),
   addresses: ["0x1234"],
   keys: [["0xabcdef"]],
 })) {
@@ -145,7 +146,8 @@ create table indexer_cursor (
   block_number integer not null,
   transaction_index integer not null,
   transaction_hash text not null,
-  event_index integer not null
+  event_index integer not null,
+  finality_status text
 );
 ```
 
@@ -163,6 +165,14 @@ block_number + transaction_hash + event_index
 
 `event_index` is scoped to the transaction, not the whole block. Do not use
 `block_number + event_index` as a unique key.
+
+When using the default pre-confirmed live stream, persist the event finality
+next to the cursor and pass it back as `cursorFinalityStatus` on restart. If the
+cursor finality is unknown and the live stream uses `PRE_CONFIRMED`,
+`streamEvents` conservatively emits a synthetic rollback for the cursor block
+and replays that block over HTTP before returning to WebSocket live indexing.
+This prevents a missed reorg from skipping replacement events that share the
+same `block_number + transaction_index + event_index` ordering.
 
 ## Schema Recommendations
 
@@ -209,6 +219,8 @@ If a process restarts with a persisted pre-confirmed cursor beyond the current
 accepted head, `streamEvents` emits a synthetic reorg message and resets its
 dedupe state to `message.rollbackCursor` before subscribing live. This prevents
 replacement events at the same cursor ordering from being skipped.
+If the accepted head has already caught up to the cursor block, the synthetic
+rollback starts at the cursor block and the HTTP backfill leg replays that block.
 
 ## Finality
 

--- a/packages/starknet-rpc/README.md
+++ b/packages/starknet-rpc/README.md
@@ -150,15 +150,11 @@ the event cursor fields that created or last updated each row, including
 
 ## Reorg Rollback
 
-On a reorg message, rollback all chain-derived rows where:
+On a reorg message, roll back all chain-derived rows where:
 
 ```sql
 block_number >= starting_block_number
 ```
-
-For Summit, `adventurer_tokens` is chain-derived and should roll back by
-`first_seen_block_number`. `cartridge_names` is an external cache and should not
-roll back.
 
 After the caller handles the rollback, `streamEvents` resumes from the reorg
 starting block with HTTP backfill and then returns to WebSocket live indexing.
@@ -171,25 +167,11 @@ Phase 1 targets accepted L2 events by default:
 finalityStatus: "ACCEPTED_ON_L2"
 ```
 
-Summit currently uses Apibara `StarknetStream` with pending finality. The first
-migration should test accepted-only indexing unless pending support is added
-explicitly.
+This does not index pending or pre-confirmed events. Applications that require
+non-accepted events should add that support explicitly and validate the cursor
+and rollback behavior for those finality modes.
 
-## Summit Migration Notes
-
-Use `/workspace/summit/indexer` as the first local client after this package is
-linkable.
-
-Recommended migration steps:
-
-1. Replace `StarknetStream` event ingestion with `streamEvents`.
-2. Persist `(block_number, transaction_index, transaction_hash, event_index)`
-   atomically with each event-derived write.
-3. Add rollback handling for chain-derived tables on reorg messages.
-4. Keep external caches, including `cartridge_names`, outside the rollback path.
-5. Run Summit against accepted-only events first.
-6. Add pending or pre-confirmed support only after the accepted-only path is
-   verified.
+## Live Integration Tests
 
 Optional live integration tests should read URLs from:
 

--- a/packages/starknet-rpc/README.md
+++ b/packages/starknet-rpc/README.md
@@ -135,6 +135,62 @@ JSON-RPC errors are surfaced to the caller. Direct `getEvents` and
 `backfillEvents` calls do not add a global rate limiter; callers indexing large
 histories should choose a node and `chunkSize` appropriate for their rate limits.
 
+## Apibara RPC Stream
+
+`StarknetRpcStream` implements the same `RpcStreamConfig` shape used by
+`@apibara/evm-rpc`:
+
+```ts
+import { createRpcClient } from "@apibara/protocol/rpc";
+import { StarknetRpcStream } from "@apibara/starknet-rpc";
+
+const client = createRpcClient(
+  new StarknetRpcStream({
+    url: process.env.STARKNET_RPC_URL!,
+    getEventsRangeSize: 1_000n,
+    headRefreshIntervalMs: 1_000,
+  }),
+);
+
+for await (const message of client.streamData({
+  filter: [
+    {
+      addresses: ["0x1234"],
+      keys: [["0xabcdef"]],
+    },
+  ],
+  startingCursor: { orderKey: 0n },
+})) {
+  // message.data.data contains event-focused StarknetRpcBlock values.
+}
+```
+
+This adapter is for accepted event blocks fetched over HTTP. Use `streamEvents`
+when the indexer needs the low-latency pre-confirmed WebSocket path.
+
+Apibara CLI indexers can use the adapter without a DNA `streamUrl`:
+
+```ts
+import { defineIndexer } from "apibara/indexer";
+import { StarknetRpcStream } from "@apibara/starknet-rpc";
+
+export default defineIndexer(
+  new StarknetRpcStream({
+    url: process.env.STARKNET_RPC_URL!,
+  }),
+)({
+  filter: {
+    addresses: ["0x1234"],
+    keys: [["0xabcdef"]],
+  },
+  async transform({ block }) {
+    for (const event of block.events) {
+      // Persist accepted events.
+    }
+  },
+});
+```
+
 ## Cursor Contract
 
 Persist the cursor in the same transaction as the indexed rows derived from the
@@ -173,6 +229,11 @@ cursor finality is unknown and the live stream uses `PRE_CONFIRMED`,
 and replays that block over HTTP before returning to WebSocket live indexing.
 This prevents a missed reorg from skipping replacement events that share the
 same `block_number + transaction_index + event_index` ordering.
+
+Pre-confirmed subscriptions may deliver the same stable event identity again
+when finality or `block_hash` changes. The subscription helpers dedupe exact
+replays, but they emit these finality updates so callers can update the
+persisted row and cursor finality.
 
 ## Schema Recommendations
 

--- a/packages/starknet-rpc/README.md
+++ b/packages/starknet-rpc/README.md
@@ -112,6 +112,16 @@ for await (const message of streamEvents({
 
 This avoids a missing-event window between HTTP and WebSocket indexing.
 
+If the WebSocket handoff block has fallen outside the node's subscription
+history window, `streamEvents` catches the `TooManyBlocksBack` response, runs
+another HTTP catch-up pass to the latest accepted head, and retries the live
+subscription from the newer block.
+
+`streamEvents` retries transport-level HTTP failures with exponential backoff.
+JSON-RPC errors are surfaced to the caller. Direct `getEvents` and
+`backfillEvents` calls do not add a global rate limiter; callers indexing large
+histories should choose a node and `chunkSize` appropriate for their rate limits.
+
 ## Cursor Contract
 
 Persist the cursor in the same transaction as the indexed rows derived from the

--- a/packages/starknet-rpc/README.md
+++ b/packages/starknet-rpc/README.md
@@ -161,15 +161,21 @@ starting block with HTTP backfill and then returns to WebSocket live indexing.
 
 ## Finality
 
-Phase 1 targets accepted L2 events by default:
+Phase 1 is designed for low-latency Starknet event indexing:
 
-```ts
-finalityStatus: "ACCEPTED_ON_L2"
-```
+- `backfillEvents` and the HTTP backfill leg of `streamEvents` use
+  `starknet_getEvents` for accepted historical events.
+- `subscribeEvents` and the live WebSocket leg of `streamEvents` subscribe with
+  `finalityStatus: "PRE_CONFIRMED"` by default.
 
-This does not index pending or pre-confirmed events. Applications that require
-non-accepted events should add that support explicitly and validate the cursor
-and rollback behavior for those finality modes.
+Callers can override `finalityStatus` when they need accepted-only live
+indexing, but the default live path is pre-confirmed so applications can observe
+new events as soon as the Starknet node publishes them over
+`starknet_subscribeEvents`.
+
+Pre-confirmed events can be reorged. Callers must persist cursors atomically
+with indexed rows and honor reorg messages by rolling back all chain-derived rows
+where `block_number >= starting_block_number`.
 
 ## Live Integration Tests
 

--- a/packages/starknet-rpc/README.md
+++ b/packages/starknet-rpc/README.md
@@ -11,6 +11,17 @@ This package is the phase 1 RPC path for Starknet indexing. It uses:
 
 It does not use the Apibara DNA runtime as a block cache.
 
+## Requirements
+
+Use Starknet JSON-RPC v0.10 or newer endpoints, for example URLs ending in
+`/rpc/v0_10` and `/ws/rpc/v0_10`.
+
+This package relies on `block_number`, `transaction_index`, and `event_index`
+from emitted events for duplicate-safe cursoring. Older RPC versions do not
+include all of these fields. Pre-confirmed live indexing also requires a node
+that includes those cursor fields in `starknet_subscribeEvents` notifications.
+Pathfinder v0.10 provides them.
+
 ## Backfill
 
 ```ts

--- a/packages/starknet-rpc/README.md
+++ b/packages/starknet-rpc/README.md
@@ -16,6 +16,10 @@ It does not use the Apibara DNA runtime as a block cache.
 Use Starknet JSON-RPC v0.10 or newer endpoints, for example URLs ending in
 `/rpc/v0_10` and `/ws/rpc/v0_10`.
 
+The package targets modern Node.js runtimes with global `fetch` support. It
+ships a default WebSocket client for Node environments, and callers can still
+provide `webSocketFactory` when they need a custom transport.
+
 This package relies on `block_number`, `transaction_index`, and `event_index`
 from emitted events for duplicate-safe cursoring. Older RPC versions do not
 include all of these fields. Pre-confirmed live indexing also requires a node

--- a/packages/starknet-rpc/README.md
+++ b/packages/starknet-rpc/README.md
@@ -1,0 +1,192 @@
+# @apibara/starknet-rpc
+
+Event-focused Starknet JSON-RPC helpers for indexers.
+
+This package is the phase 1 RPC path for Starknet indexing. It uses:
+
+- `starknet_getEvents` over HTTP for historical backfills.
+- `starknet_subscribeEvents` over WebSocket for recent live indexing.
+- Explicit event cursors.
+- Explicit reorg notifications.
+
+It does not use the Apibara DNA runtime as a block cache.
+
+## Backfill
+
+```ts
+import { backfillEvents } from "@apibara/starknet-rpc";
+
+const cursor = await loadCursor();
+
+for await (const message of backfillEvents({
+  url: process.env.STARKNET_RPC_URL!,
+  fromBlock: { block_number: cursor?.blockNumber ?? 0 },
+  toBlock: "latest",
+  addresses: ["0x1234"],
+  keys: [["0xabcdef"]],
+  cursor,
+  chunkSize: 1024,
+})) {
+  await db.transaction(async (tx) => {
+    await insertEvent(tx, message.event);
+    await saveCursor(tx, message.cursor);
+  });
+}
+```
+
+`cursor` means "last successfully persisted event". When a cursor is supplied,
+the backfill starts from that block and skips events at or before the cursor.
+
+## Live Subscription
+
+```ts
+import { subscribeEvents } from "@apibara/starknet-rpc";
+
+const subscription = subscribeEvents({
+  url: process.env.STARKNET_WS_URL!,
+  blockId: "latest",
+  addresses: ["0x1234"],
+  keys: [["0xabcdef"]],
+});
+
+try {
+  for await (const message of subscription) {
+    if (message.type === "reorg") {
+      await rollbackFrom(message.reorg.startingBlockNumber);
+      continue;
+    }
+
+    await persistEvent(message.event, message.cursor);
+  }
+} finally {
+  await subscription.unsubscribe();
+}
+```
+
+Subscriptions are for recent live indexing. If a node rejects the requested
+`blockId` with `TooManyBlocksBack`, use HTTP backfill first and then subscribe
+from a recent accepted head.
+
+## Combined Stream
+
+```ts
+import { streamEvents } from "@apibara/starknet-rpc";
+
+for await (const message of streamEvents({
+  url: process.env.STARKNET_RPC_URL!,
+  wsUrl: process.env.STARKNET_WS_URL!,
+  fromBlock: { block_number: 0 },
+  cursor: await loadCursor(),
+  addresses: ["0x1234"],
+  keys: [["0xabcdef"]],
+})) {
+  if (message.type === "reorg") {
+    await rollbackFrom(message.reorg.startingBlockNumber);
+    continue;
+  }
+
+  await db.transaction(async (tx) => {
+    await insertEvent(tx, message.event);
+    await saveCursor(tx, message.cursor);
+  });
+}
+```
+
+`streamEvents` performs an inclusive HTTP-to-WS handoff:
+
+1. Reads the current accepted head.
+2. Backfills with `starknet_getEvents` through that head.
+3. Subscribes with `starknet_subscribeEvents` from the same head.
+4. Deduplicates replayed events using the persisted cursor identity.
+
+This avoids a missing-event window between HTTP and WebSocket indexing.
+
+## Cursor Contract
+
+Persist the cursor in the same transaction as the indexed rows derived from the
+event:
+
+```sql
+create table indexer_cursor (
+  id text primary key,
+  block_number integer not null,
+  transaction_hash text not null,
+  event_index integer not null
+);
+```
+
+The stable event identity is:
+
+```text
+block_number + transaction_hash + event_index
+```
+
+`event_index` is scoped to the transaction, not the whole block. Do not use
+`block_number + event_index` as a unique key.
+
+## Schema Recommendations
+
+For event-derived tables, store:
+
+- `block_number`
+- `block_hash`
+- `transaction_hash`
+- `event_index`
+- contract address
+- normalized selector or first key
+
+Use a unique constraint on `(block_number, transaction_hash, event_index)` for
+raw event rows. Domain tables can use their own keys, but they should also store
+the event cursor fields that created or last updated each row.
+
+## Reorg Rollback
+
+On a reorg message, rollback all chain-derived rows where:
+
+```sql
+block_number >= starting_block_number
+```
+
+For Summit, `adventurer_tokens` is chain-derived and should roll back by
+`first_seen_block_number`. `cartridge_names` is an external cache and should not
+roll back.
+
+After the caller handles the rollback, `streamEvents` resumes from the reorg
+starting block with HTTP backfill and then returns to WebSocket live indexing.
+
+## Finality
+
+Phase 1 targets accepted L2 events by default:
+
+```ts
+finalityStatus: "ACCEPTED_ON_L2"
+```
+
+Summit currently uses Apibara `StarknetStream` with pending finality. The first
+migration should test accepted-only indexing unless pending support is added
+explicitly.
+
+## Summit Migration Notes
+
+Use `/workspace/summit/indexer` as the first local client after this package is
+linkable.
+
+Recommended migration steps:
+
+1. Replace `StarknetStream` event ingestion with `streamEvents`.
+2. Persist `(block_number, transaction_hash, event_index)` atomically with each
+   event-derived write.
+3. Add rollback handling for chain-derived tables on reorg messages.
+4. Keep external caches, including `cartridge_names`, outside the rollback path.
+5. Run Summit against accepted-only events first.
+6. Add pending or pre-confirmed support only after the accepted-only path is
+   verified.
+
+Optional live integration tests should read URLs from:
+
+```sh
+TEST_STARKNET_RPC_URL=...
+TEST_STARKNET_WS_URL=...
+```
+
+Do not commit full-node URLs into tests or examples.

--- a/packages/starknet-rpc/README.md
+++ b/packages/starknet-rpc/README.md
@@ -1,106 +1,31 @@
 # @apibara/starknet-rpc
 
-Event-focused Starknet JSON-RPC helpers for indexers.
+Starknet JSON-RPC event indexing helpers for Apibara indexers.
 
-This package is the phase 1 RPC path for Starknet indexing. It uses:
+This package supports:
 
-- `starknet_getEvents` over HTTP for historical backfills.
-- `starknet_subscribeEvents` over WebSocket for recent live indexing.
-- Explicit event cursors.
-- Explicit reorg notifications.
-
-It does not use the Apibara DNA runtime as a block cache.
+- historical event backfill with `starknet_getEvents` over HTTP
+- live event indexing with `starknet_subscribeEvents` over WebSocket
+- explicit event cursors
+- reorg notifications and rollback cursors
+- an Apibara `RpcStreamConfig` adapter for accepted event blocks
 
 ## Requirements
 
-Use Starknet JSON-RPC v0.10 or newer endpoints, for example URLs ending in
-`/rpc/v0_10` and `/ws/rpc/v0_10`.
+Use a Starknet JSON-RPC v0.10 or newer endpoint, for example `/rpc/v0_10`
+and `/ws/rpc/v0_10`.
 
-The package targets modern Node.js runtimes with global `fetch` support. It
-ships a default WebSocket client for Node environments, and callers can still
-provide `webSocketFactory` when they need a custom transport.
+The RPC node must include `block_number`, `transaction_index`, and
+`event_index` in event payloads. These fields are required for duplicate-safe
+cursoring and resume behavior.
 
-This package relies on `block_number`, `transaction_index`, and `event_index`
-from emitted events for duplicate-safe cursoring. Older RPC versions do not
-include all of these fields. Pre-confirmed live indexing also requires a node
-that includes those cursor fields in `starknet_subscribeEvents` notifications.
-Pathfinder v0.10 provides them.
+The package targets modern Node.js runtimes with global `fetch` support. A
+default Node WebSocket client is included, and custom transports can be provided
+with `webSocketFactory`.
 
-## Backfill
+## Recommended Usage
 
-```ts
-import { backfillEvents } from "@apibara/starknet-rpc";
-
-const cursor = await loadCursor();
-
-for await (const message of backfillEvents({
-  url: process.env.STARKNET_RPC_URL!,
-  fromBlock: { block_number: cursor?.blockNumber ?? 0 },
-  toBlock: "latest",
-  addresses: ["0x1234"],
-  keys: [["0xabcdef"]],
-  cursor,
-  chunkSize: 1024,
-})) {
-  await db.transaction(async (tx) => {
-    await insertEvent(tx, message.event);
-    await saveCursor(tx, message.cursor);
-  });
-}
-```
-
-`cursor` means "last successfully persisted event". When a cursor is supplied,
-the backfill starts from that block and skips events at or before the cursor.
-Reorg handling should persist `message.rollbackCursor`; that cursor sorts before
-the first event in the rollback block.
-
-## Live Subscription
-
-```ts
-import { subscribeEvents } from "@apibara/starknet-rpc";
-
-const subscription = subscribeEvents({
-  url: process.env.STARKNET_WS_URL!,
-  blockId: "latest",
-  addresses: ["0x1234"],
-  keys: [["0xabcdef"]],
-  idleTimeoutMs: 60_000,
-  maxQueueSize: 10_000,
-  reconnect: {
-    minDelayMs: 500,
-    maxDelayMs: 10_000,
-  },
-});
-
-try {
-  for await (const message of subscription) {
-    if (message.type === "reorg") {
-      await db.transaction(async (tx) => {
-        await rollbackFrom(tx, message.reorg.startingBlockNumber);
-        await saveCursor(tx, message.rollbackCursor);
-      });
-      continue;
-    }
-
-    await persistEvent(message.event, message.cursor);
-  }
-} finally {
-  await subscription.unsubscribe();
-}
-```
-
-Subscriptions are for recent live indexing. If a node rejects the requested
-`blockId` with `TooManyBlocksBack`, use HTTP backfill first and then subscribe
-from a recent accepted head.
-
-The WebSocket helpers close and reconnect when the connection is idle for
-`idleTimeoutMs` milliseconds. Set `idleTimeoutMs: 0` to disable this watchdog.
-Incoming messages are also bounded by `maxQueueSize`; if the consumer falls too
-far behind, the subscription closes instead of buffering without limit. Use
-`reconnect.maxAttempts` when a misconfigured endpoint should fail permanently
-instead of retrying forever.
-
-## Combined Stream
+Use `streamEvents` when you want historical backfill followed by live indexing:
 
 ```ts
 import { streamEvents } from "@apibara/starknet-rpc";
@@ -129,59 +54,73 @@ for await (const message of streamEvents({
 }
 ```
 
-`streamEvents` performs an inclusive HTTP-to-WS handoff:
+`streamEvents` backfills accepted events over HTTP, then switches to a live
+WebSocket subscription. Live subscriptions use `PRE_CONFIRMED` finality by
+default for low-latency indexing.
 
-1. Reads the current accepted head.
-2. Backfills with `starknet_getEvents` through that head.
-3. Subscribes with `starknet_subscribeEvents` from the same head.
-4. Deduplicates replayed events using the persisted cursor identity.
+## HTTP Backfill
 
-This avoids a missing-event window between HTTP and WebSocket indexing.
-
-If the WebSocket handoff block has fallen outside the node's subscription
-history window, `streamEvents` catches the `TooManyBlocksBack` response, runs
-another HTTP catch-up pass to the latest accepted head, and retries the live
-subscription from the newer block.
-
-`streamEvents` retries transport-level HTTP failures with exponential backoff.
-JSON-RPC errors are surfaced to the caller. Direct `getEvents` and
-`backfillEvents` calls do not add a global rate limiter; callers indexing large
-histories should choose a node and `chunkSize` appropriate for their rate limits.
-
-## Apibara RPC Stream
-
-`StarknetRpcStream` implements the same `RpcStreamConfig` shape used by
-`@apibara/evm-rpc`:
+Use `backfillEvents` for bounded or standalone historical indexing:
 
 ```ts
-import { createRpcClient } from "@apibara/protocol/rpc";
-import { StarknetRpcStream } from "@apibara/starknet-rpc";
+import { backfillEvents } from "@apibara/starknet-rpc";
 
-const client = createRpcClient(
-  new StarknetRpcStream({
-    url: process.env.STARKNET_RPC_URL!,
-    getEventsRangeSize: 1_000n,
-    headRefreshIntervalMs: 1_000,
-  }),
-);
-
-for await (const message of client.streamData({
-  filter: [
-    {
-      addresses: ["0x1234"],
-      keys: [["0xabcdef"]],
-    },
-  ],
-  startingCursor: { orderKey: 0n },
+for await (const message of backfillEvents({
+  url: process.env.STARKNET_RPC_URL!,
+  fromBlock: { block_number: 0 },
+  toBlock: "latest",
+  addresses: ["0x1234"],
+  keys: [["0xabcdef"]],
+  cursor: await loadCursor(),
+  chunkSize: 1024,
 })) {
-  // message.data.data contains event-focused StarknetRpcBlock values.
+  await db.transaction(async (tx) => {
+    await insertEvent(tx, message.event);
+    await saveCursor(tx, message.cursor);
+  });
 }
 ```
 
-This adapter is for accepted event blocks fetched over HTTP. Use `streamEvents`
-when the indexer needs the low-latency pre-confirmed WebSocket path.
+## Live Subscriptions
 
-Apibara CLI indexers can use the adapter without a DNA `streamUrl`:
+Use `subscribeEvents` when you only need the WebSocket subscription layer:
+
+```ts
+import { subscribeEvents } from "@apibara/starknet-rpc";
+
+const subscription = subscribeEvents({
+  url: process.env.STARKNET_WS_URL!,
+  blockId: "latest",
+  addresses: ["0x1234"],
+  keys: [["0xabcdef"]],
+  idleTimeoutMs: 60_000,
+  maxQueueSize: 10_000,
+});
+
+try {
+  for await (const message of subscription) {
+    if (message.type === "reorg") {
+      await db.transaction(async (tx) => {
+        await rollbackFrom(tx, message.reorg.startingBlockNumber);
+        await saveCursor(tx, message.rollbackCursor);
+      });
+      continue;
+    }
+
+    await db.transaction(async (tx) => {
+      await insertEvent(tx, message.event);
+      await saveCursor(tx, message.cursor);
+    });
+  }
+} finally {
+  await subscription.unsubscribe();
+}
+```
+
+## Apibara RPC Stream
+
+`StarknetRpcStream` implements Apibara's `RpcStreamConfig` interface for
+accepted event blocks fetched over HTTP:
 
 ```ts
 import { defineIndexer } from "apibara/indexer";
@@ -204,129 +143,34 @@ export default defineIndexer(
 });
 ```
 
-## Cursor Contract
+Use `streamEvents` instead when you need the pre-confirmed WebSocket path.
 
-Persist the cursor in the same transaction as the indexed rows derived from the
-event:
+## Cursor and Reorg Contract
 
-```sql
-create table indexer_cursor (
-  id text primary key,
-  block_number integer not null,
-  transaction_index integer not null,
-  transaction_hash text not null,
-  event_index integer not null,
-  finality_status text
-);
-```
+Persist the cursor in the same transaction as the rows derived from the event.
 
-Cursor ordering and resume semantics use:
+Cursor ordering uses:
 
 ```text
 block_number + transaction_index + event_index
 ```
 
-The stable event identity is:
+Stable event identity uses:
 
 ```text
 block_number + transaction_hash + event_index
 ```
 
-`event_index` is scoped to the transaction, not the whole block. Do not use
-`block_number + event_index` as a unique key.
+`event_index` is scoped to the transaction, not the whole block.
 
-When using the default pre-confirmed live stream, persist the event finality
-next to the cursor and pass it back as `cursorFinalityStatus` on restart. If the
-cursor finality is unknown and the live stream uses `PRE_CONFIRMED`,
-`streamEvents` conservatively emits a synthetic rollback for the cursor block
-and replays that block over HTTP before returning to WebSocket live indexing.
-This prevents a missed reorg from skipping replacement events that share the
-same `block_number + transaction_index + event_index` ordering.
+For pre-confirmed indexing, persist cursor finality and pass it back as
+`cursorFinalityStatus` on restart. This lets the stream resume without skipping
+accepted replacement events after reorgs.
 
-If cursor finality is not persisted, this conservative replay happens on every
-restart of a pre-confirmed stream. Rollback and transform handlers should be
-idempotent, especially when they perform external side effects. Persisting
-`finality_status` and passing `cursorFinalityStatus` avoids unnecessary
-cursor-block rollbacks once the cursor is known to be accepted.
-
-Pre-confirmed subscriptions may deliver the same stable event identity again
-when finality or `block_hash` changes. The subscription helpers dedupe exact
-replays, but they emit these finality updates so callers can update the
-persisted row and cursor finality.
-
-## Schema Recommendations
-
-For event-derived tables, store:
-
-- `block_number`
-- `block_hash`
-- `transaction_index`
-- `transaction_hash`
-- `event_index`
-- contract address
-- normalized selector or first key
-
-Use a unique constraint on `(block_number, transaction_hash, event_index)` for
-raw event rows. Domain tables can use their own keys, but they should also store
-the event cursor fields that created or last updated each row, including
-`transaction_index` for ordering.
-
-## Reorg Rollback
-
-On a reorg message, roll back all chain-derived rows where:
+When receiving a reorg message, delete or roll back all chain-derived rows where:
 
 ```sql
 block_number >= starting_block_number
 ```
 
-Update the persisted cursor to `message.rollbackCursor` in the same transaction
-as the chain-row rollback:
-
-```ts
-await db.transaction(async (tx) => {
-  await tx.sql`
-    delete from indexed_events
-    where block_number >= ${message.reorg.startingBlockNumber}
-  `;
-
-  await saveCursor(tx, message.rollbackCursor);
-});
-```
-
-After the caller handles the rollback, `streamEvents` resumes from the reorg
-starting block with HTTP backfill and then returns to WebSocket live indexing.
-If a process restarts with a persisted pre-confirmed cursor beyond the current
-accepted head, `streamEvents` emits a synthetic reorg message and resets its
-dedupe state to `message.rollbackCursor` before subscribing live. This prevents
-replacement events at the same cursor ordering from being skipped.
-If the accepted head has already caught up to the cursor block, the synthetic
-rollback starts at the cursor block and the HTTP backfill leg replays that block.
-
-## Finality
-
-Phase 1 is designed for low-latency Starknet event indexing:
-
-- `backfillEvents` and the HTTP backfill leg of `streamEvents` use
-  `starknet_getEvents` for accepted historical events.
-- `subscribeEvents` and the live WebSocket leg of `streamEvents` subscribe with
-  `finalityStatus: "PRE_CONFIRMED"` by default.
-
-Callers can override `finalityStatus` when they need accepted-only live
-indexing, but the default live path is pre-confirmed so applications can observe
-new events as soon as the Starknet node publishes them over
-`starknet_subscribeEvents`.
-
-Pre-confirmed events can be reorged. Callers must persist cursors atomically
-with indexed rows and honor reorg messages by rolling back all chain-derived rows
-where `block_number >= starting_block_number`.
-
-## Live Integration Tests
-
-Optional live integration tests should read URLs from:
-
-```sh
-TEST_STARKNET_RPC_URL=...
-TEST_STARKNET_WS_URL=...
-```
-
-Do not commit full-node URLs into tests or examples.
+Then persist `message.rollbackCursor` in the same transaction.

--- a/packages/starknet-rpc/README.md
+++ b/packages/starknet-rpc/README.md
@@ -110,9 +110,16 @@ event:
 create table indexer_cursor (
   id text primary key,
   block_number integer not null,
+  transaction_index integer not null,
   transaction_hash text not null,
   event_index integer not null
 );
+```
+
+Cursor ordering and resume semantics use:
+
+```text
+block_number + transaction_index + event_index
 ```
 
 The stable event identity is:
@@ -130,6 +137,7 @@ For event-derived tables, store:
 
 - `block_number`
 - `block_hash`
+- `transaction_index`
 - `transaction_hash`
 - `event_index`
 - contract address
@@ -137,7 +145,8 @@ For event-derived tables, store:
 
 Use a unique constraint on `(block_number, transaction_hash, event_index)` for
 raw event rows. Domain tables can use their own keys, but they should also store
-the event cursor fields that created or last updated each row.
+the event cursor fields that created or last updated each row, including
+`transaction_index` for ordering.
 
 ## Reorg Rollback
 
@@ -174,8 +183,8 @@ linkable.
 Recommended migration steps:
 
 1. Replace `StarknetStream` event ingestion with `streamEvents`.
-2. Persist `(block_number, transaction_hash, event_index)` atomically with each
-   event-derived write.
+2. Persist `(block_number, transaction_index, transaction_hash, event_index)`
+   atomically with each event-derived write.
 3. Add rollback handling for chain-derived tables on reorg messages.
 4. Keep external caches, including `cartridge_names`, outside the rollback path.
 5. Run Summit against accepted-only events first.

--- a/packages/starknet-rpc/README.md
+++ b/packages/starknet-rpc/README.md
@@ -64,6 +64,12 @@ const subscription = subscribeEvents({
   blockId: "latest",
   addresses: ["0x1234"],
   keys: [["0xabcdef"]],
+  idleTimeoutMs: 60_000,
+  maxQueueSize: 10_000,
+  reconnect: {
+    minDelayMs: 500,
+    maxDelayMs: 10_000,
+  },
 });
 
 try {
@@ -86,6 +92,13 @@ try {
 Subscriptions are for recent live indexing. If a node rejects the requested
 `blockId` with `TooManyBlocksBack`, use HTTP backfill first and then subscribe
 from a recent accepted head.
+
+The WebSocket helpers close and reconnect when the connection is idle for
+`idleTimeoutMs` milliseconds. Set `idleTimeoutMs: 0` to disable this watchdog.
+Incoming messages are also bounded by `maxQueueSize`; if the consumer falls too
+far behind, the subscription closes instead of buffering without limit. Use
+`reconnect.maxAttempts` when a misconfigured endpoint should fail permanently
+instead of retrying forever.
 
 ## Combined Stream
 
@@ -229,6 +242,12 @@ cursor finality is unknown and the live stream uses `PRE_CONFIRMED`,
 and replays that block over HTTP before returning to WebSocket live indexing.
 This prevents a missed reorg from skipping replacement events that share the
 same `block_number + transaction_index + event_index` ordering.
+
+If cursor finality is not persisted, this conservative replay happens on every
+restart of a pre-confirmed stream. Rollback and transform handlers should be
+idempotent, especially when they perform external side effects. Persisting
+`finality_status` and passing `cursorFinalityStatus` avoids unnecessary
+cursor-block rollbacks once the cursor is known to be accepted.
 
 Pre-confirmed subscriptions may deliver the same stable event identity again
 when finality or `block_hash` changes. The subscription helpers dedupe exact

--- a/packages/starknet-rpc/build.config.ts
+++ b/packages/starknet-rpc/build.config.ts
@@ -1,0 +1,12 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig({
+  entries: ["./src/index.ts"],
+  clean: true,
+  outDir: "./dist",
+  declaration: true,
+  sourcemap: true,
+  rollup: {
+    emitCJS: true,
+  },
+});

--- a/packages/starknet-rpc/package.json
+++ b/packages/starknet-rpc/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@apibara/starknet-rpc",
+  "version": "2.1.4",
+  "repository": "apibara/typescript-sdk",
+  "type": "module",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "unbuild",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "lint:fix": "pnpm lint --write",
+    "format": "biome format . --write",
+    "test": "vitest",
+    "test:ci": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.13",
+    "unbuild": "^2.0.0",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/starknet-rpc/package.json
+++ b/packages/starknet-rpc/package.json
@@ -3,6 +3,9 @@
   "version": "2.1.4",
   "repository": "apibara/typescript-sdk",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "files": [
     "dist",
     "src",

--- a/packages/starknet-rpc/package.json
+++ b/packages/starknet-rpc/package.json
@@ -37,6 +37,7 @@
     "vitest": "^1.6.0"
   },
   "dependencies": {
+    "@apibara/protocol": "workspace:*",
     "ws": "^8.21.0"
   }
 }

--- a/packages/starknet-rpc/package.json
+++ b/packages/starknet-rpc/package.json
@@ -29,7 +29,11 @@
   },
   "devDependencies": {
     "@types/node": "^20.12.13",
+    "@types/ws": "^8.18.1",
     "unbuild": "^2.0.0",
     "vitest": "^1.6.0"
+  },
+  "dependencies": {
+    "ws": "^8.21.0"
   }
 }

--- a/packages/starknet-rpc/src/backfill.ts
+++ b/packages/starknet-rpc/src/backfill.ts
@@ -16,7 +16,7 @@ export async function* backfillEvents(
     const page = await getEvents({
       url: options.url,
       fromBlock,
-      toBlock: options.toBlock,
+      toBlock: options.toBlock ?? "latest",
       addresses: options.addresses,
       keys: options.keys,
       chunkSize: options.chunkSize ?? DEFAULT_BACKFILL_CHUNK_SIZE,

--- a/packages/starknet-rpc/src/backfill.ts
+++ b/packages/starknet-rpc/src/backfill.ts
@@ -1,0 +1,52 @@
+import { compareEventCursor } from "./cursor";
+import { getEvents } from "./http";
+import type { BackfillEventsOptions, BlockId, EventMessage } from "./types";
+
+const DEFAULT_BACKFILL_CHUNK_SIZE = 100;
+
+export async function* backfillEvents(
+  options: BackfillEventsOptions,
+): AsyncGenerator<EventMessage, void, unknown> {
+  const fromBlock = getStartingBlock(options);
+  let continuationToken = options.cursor
+    ? undefined
+    : options.continuationToken;
+
+  do {
+    const page = await getEvents({
+      url: options.url,
+      fromBlock,
+      toBlock: options.toBlock,
+      addresses: options.addresses,
+      keys: options.keys,
+      chunkSize: options.chunkSize ?? DEFAULT_BACKFILL_CHUNK_SIZE,
+      continuationToken,
+      signal: options.signal,
+    });
+
+    for (const event of page.events) {
+      if (
+        options.cursor &&
+        compareEventCursor(event.cursor, options.cursor) <= 0
+      ) {
+        continue;
+      }
+
+      yield {
+        type: "event",
+        event,
+        cursor: event.cursor,
+      };
+    }
+
+    continuationToken = page.continuationToken;
+  } while (continuationToken !== undefined);
+}
+
+function getStartingBlock(options: BackfillEventsOptions): BlockId | undefined {
+  if (options.cursor) {
+    return { block_number: options.cursor.blockNumber };
+  }
+
+  return options.fromBlock;
+}

--- a/packages/starknet-rpc/src/block-cache.ts
+++ b/packages/starknet-rpc/src/block-cache.ts
@@ -15,20 +15,6 @@ type CachedBlock = {
   metadata: BlockMetadata;
 };
 
-type JsonRpcObjectCaller = <T>(request: {
-  url: string;
-  method: string;
-  params?: unknown;
-  signal?: AbortSignal;
-}) => Promise<T>;
-
-type JsonRpcPositionalCaller = <T>(
-  url: string,
-  method: string,
-  params?: unknown,
-  signal?: AbortSignal,
-) => Promise<T>;
-
 export class StarknetBlockCache {
   readonly #url: string;
   readonly #signal?: AbortSignal;
@@ -121,14 +107,13 @@ export async function getLatestBlock(
 
 export async function getBlockWithTxHashes(
   options: BlockCacheOptions & { blockId?: BlockId },
-  blockId?: BlockId,
 ): Promise<StarknetBlockWithTxHashes> {
-  return callJsonRpc<StarknetBlockWithTxHashes>({
-    url: options.url,
-    method: "starknet_getBlockWithTxHashes",
-    params: [blockId ?? options.blockId ?? "latest"],
-    signal: options.signal,
-  });
+  return jsonRpc<StarknetBlockWithTxHashes>(
+    options.url,
+    "starknet_getBlockWithTxHashes",
+    [options.blockId ?? "latest"],
+    options.signal,
+  );
 }
 
 function blockMetadataFromRpcBlock(
@@ -165,21 +150,6 @@ function blockMetadataFromRpcBlock(
     blockHash: normalizeFelt(block.block_hash, "block.block_hash"),
     timestamp: block.timestamp,
   };
-}
-
-async function callJsonRpc<T>(request: {
-  url: string;
-  method: string;
-  params?: unknown;
-  signal?: AbortSignal;
-}): Promise<T> {
-  const rpc = jsonRpc as JsonRpcObjectCaller & JsonRpcPositionalCaller;
-
-  if (jsonRpc.length >= 2) {
-    return rpc<T>(request.url, request.method, request.params, request.signal);
-  }
-
-  return rpc<T>(request);
 }
 
 function isBlockNumberId(

--- a/packages/starknet-rpc/src/block-cache.ts
+++ b/packages/starknet-rpc/src/block-cache.ts
@@ -4,6 +4,7 @@ import type { BlockCacheOptions, BlockId, BlockMetadata, Felt } from "./types";
 
 export interface StarknetBlockWithTxHashes {
   block_hash?: Felt;
+  parent_hash?: Felt;
   block_number?: number;
   timestamp?: number;
   transactions?: Felt[];

--- a/packages/starknet-rpc/src/block-cache.ts
+++ b/packages/starknet-rpc/src/block-cache.ts
@@ -1,0 +1,199 @@
+import { jsonRpc } from "./http";
+import { normalizeFelt } from "./normalize";
+import type { BlockCacheOptions, BlockId, BlockMetadata, Felt } from "./types";
+
+export interface StarknetBlockWithTxHashes {
+  block_hash?: Felt;
+  block_number?: number;
+  timestamp?: number;
+  transactions?: Felt[];
+  [key: string]: unknown;
+}
+
+type CachedBlock = {
+  block: StarknetBlockWithTxHashes;
+  metadata: BlockMetadata;
+};
+
+type JsonRpcObjectCaller = <T>(request: {
+  url: string;
+  method: string;
+  params?: unknown;
+  signal?: AbortSignal;
+}) => Promise<T>;
+
+type JsonRpcPositionalCaller = <T>(
+  url: string,
+  method: string,
+  params?: unknown,
+  signal?: AbortSignal,
+) => Promise<T>;
+
+export class StarknetBlockCache {
+  readonly #url: string;
+  readonly #signal?: AbortSignal;
+  readonly #blocksByNumber = new Map<number, CachedBlock>();
+  readonly #blocksByHash = new Map<Felt, CachedBlock>();
+
+  constructor(options: BlockCacheOptions) {
+    this.#url = options.url;
+    this.#signal = options.signal;
+  }
+
+  async getLatestBlock(): Promise<BlockMetadata> {
+    const block = await getBlockWithTxHashes({
+      url: this.#url,
+      blockId: "latest",
+      signal: this.#signal,
+    });
+    return this.#remember(block).metadata;
+  }
+
+  async getBlockWithTxHashes(
+    blockId: BlockId,
+  ): Promise<StarknetBlockWithTxHashes> {
+    const cached = this.#getCached(blockId);
+    if (cached) {
+      return cached.block;
+    }
+
+    const block = await getBlockWithTxHashes({
+      url: this.#url,
+      blockId,
+      signal: this.#signal,
+    });
+
+    return this.#remember(block).block;
+  }
+
+  getCachedMetadata(blockId: BlockId): BlockMetadata | undefined {
+    return this.#getCached(blockId)?.metadata;
+  }
+
+  invalidateFrom(startingBlockNumber: number): void {
+    if (!Number.isInteger(startingBlockNumber) || startingBlockNumber < 0) {
+      throw new Error("startingBlockNumber must be a non-negative integer");
+    }
+
+    for (const [blockNumber, cached] of this.#blocksByNumber) {
+      if (blockNumber >= startingBlockNumber) {
+        this.#blocksByNumber.delete(blockNumber);
+        this.#blocksByHash.delete(cached.metadata.blockHash);
+      }
+    }
+  }
+
+  #getCached(blockId: BlockId): CachedBlock | undefined {
+    if (isBlockNumberId(blockId)) {
+      return this.#blocksByNumber.get(blockId.block_number);
+    }
+
+    if (isBlockHashId(blockId)) {
+      return this.#blocksByHash.get(
+        normalizeFelt(blockId.block_hash, "blockId.block_hash"),
+      );
+    }
+
+    return undefined;
+  }
+
+  #remember(block: StarknetBlockWithTxHashes): CachedBlock {
+    const metadata = blockMetadataFromRpcBlock(block);
+    const cached = { block, metadata };
+
+    this.#blocksByNumber.set(metadata.blockNumber, cached);
+    this.#blocksByHash.set(metadata.blockHash, cached);
+
+    return cached;
+  }
+}
+
+export async function getLatestBlock(
+  options: BlockCacheOptions,
+): Promise<BlockMetadata> {
+  const block = await getBlockWithTxHashes({
+    ...options,
+    blockId: "latest",
+  });
+
+  return blockMetadataFromRpcBlock(block);
+}
+
+export async function getBlockWithTxHashes(
+  options: BlockCacheOptions & { blockId?: BlockId },
+  blockId?: BlockId,
+): Promise<StarknetBlockWithTxHashes> {
+  return callJsonRpc<StarknetBlockWithTxHashes>({
+    url: options.url,
+    method: "starknet_getBlockWithTxHashes",
+    params: { block_id: blockId ?? options.blockId ?? "latest" },
+    signal: options.signal,
+  });
+}
+
+function blockMetadataFromRpcBlock(
+  block: StarknetBlockWithTxHashes,
+): BlockMetadata {
+  if (
+    typeof block.block_number !== "number" ||
+    !Number.isInteger(block.block_number) ||
+    block.block_number < 0
+  ) {
+    throw new Error(
+      "starknet_getBlockWithTxHashes response is missing block_number",
+    );
+  }
+
+  if (typeof block.block_hash !== "string") {
+    throw new Error(
+      "starknet_getBlockWithTxHashes response is missing block_hash",
+    );
+  }
+
+  if (
+    typeof block.timestamp !== "number" ||
+    !Number.isInteger(block.timestamp) ||
+    block.timestamp < 0
+  ) {
+    throw new Error(
+      "starknet_getBlockWithTxHashes response is missing timestamp",
+    );
+  }
+
+  return {
+    blockNumber: block.block_number,
+    blockHash: normalizeFelt(block.block_hash, "block.block_hash"),
+    timestamp: block.timestamp,
+  };
+}
+
+async function callJsonRpc<T>(request: {
+  url: string;
+  method: string;
+  params?: unknown;
+  signal?: AbortSignal;
+}): Promise<T> {
+  const rpc = jsonRpc as JsonRpcObjectCaller & JsonRpcPositionalCaller;
+
+  if (jsonRpc.length >= 2) {
+    return rpc<T>(request.url, request.method, request.params, request.signal);
+  }
+
+  return rpc<T>(request);
+}
+
+function isBlockNumberId(
+  blockId: BlockId | undefined,
+): blockId is { block_number: number } {
+  return (
+    typeof blockId === "object" && blockId !== null && "block_number" in blockId
+  );
+}
+
+function isBlockHashId(
+  blockId: BlockId | undefined,
+): blockId is { block_hash: Felt } {
+  return (
+    typeof blockId === "object" && blockId !== null && "block_hash" in blockId
+  );
+}

--- a/packages/starknet-rpc/src/block-cache.ts
+++ b/packages/starknet-rpc/src/block-cache.ts
@@ -126,7 +126,7 @@ export async function getBlockWithTxHashes(
   return callJsonRpc<StarknetBlockWithTxHashes>({
     url: options.url,
     method: "starknet_getBlockWithTxHashes",
-    params: { block_id: blockId ?? options.blockId ?? "latest" },
+    params: [blockId ?? options.blockId ?? "latest"],
     signal: options.signal,
   });
 }

--- a/packages/starknet-rpc/src/constants.ts
+++ b/packages/starknet-rpc/src/constants.ts
@@ -1,0 +1,4 @@
+import type { SubscriptionFinalityStatus } from "./types";
+
+export const DEFAULT_SUBSCRIPTION_FINALITY_STATUS: SubscriptionFinalityStatus =
+  "PRE_CONFIRMED";

--- a/packages/starknet-rpc/src/cursor.ts
+++ b/packages/starknet-rpc/src/cursor.ts
@@ -28,3 +28,16 @@ export function eventCursorKey(cursor: EventCursor): string {
     cursor.eventIndex,
   ].join(":");
 }
+
+export function cursorBeforeBlock(blockNumber: number): EventCursor {
+  return {
+    blockNumber,
+    transactionIndex: -1,
+    transactionHash: "0x0",
+    eventIndex: -1,
+  };
+}
+
+export function isCursorBeforeBlock(cursor: EventCursor): boolean {
+  return cursor.transactionIndex < 0 || cursor.eventIndex < 0;
+}

--- a/packages/starknet-rpc/src/cursor.ts
+++ b/packages/starknet-rpc/src/cursor.ts
@@ -1,5 +1,5 @@
 import { normalizeFelt } from "./normalize";
-import type { EventCursor } from "./types";
+import type { EventCursor, NormalizedEvent } from "./types";
 
 export function compareEventCursor(a: EventCursor, b: EventCursor): number {
   if (a.blockNumber !== b.blockNumber) {
@@ -26,6 +26,16 @@ export function eventCursorKey(cursor: EventCursor): string {
     cursor.blockNumber,
     normalizeFelt(cursor.transactionHash, "cursor.transactionHash"),
     cursor.eventIndex,
+  ].join(":");
+}
+
+export function eventVersionKey(event: NormalizedEvent): string {
+  return [
+    event.finalityStatus ?? "",
+    event.blockHash ?? "",
+    event.fromAddress,
+    event.keys.join(","),
+    event.data.join(","),
   ].join(":");
 }
 

--- a/packages/starknet-rpc/src/cursor.ts
+++ b/packages/starknet-rpc/src/cursor.ts
@@ -1,0 +1,39 @@
+import { normalizeFelt } from "./normalize";
+import type { EventCursor } from "./types";
+
+export function compareEventCursor(a: EventCursor, b: EventCursor): number {
+  if (a.blockNumber !== b.blockNumber) {
+    return a.blockNumber < b.blockNumber ? -1 : 1;
+  }
+
+  const aTransactionHash = normalizeFelt(
+    a.transactionHash,
+    "cursor.transactionHash",
+  );
+  const bTransactionHash = normalizeFelt(
+    b.transactionHash,
+    "cursor.transactionHash",
+  );
+
+  if (aTransactionHash !== bTransactionHash) {
+    return aTransactionHash < bTransactionHash ? -1 : 1;
+  }
+
+  if (a.eventIndex !== b.eventIndex) {
+    return a.eventIndex < b.eventIndex ? -1 : 1;
+  }
+
+  return 0;
+}
+
+export function cursorEquals(a: EventCursor, b: EventCursor): boolean {
+  return compareEventCursor(a, b) === 0;
+}
+
+export function eventCursorKey(cursor: EventCursor): string {
+  return [
+    cursor.blockNumber,
+    normalizeFelt(cursor.transactionHash, "cursor.transactionHash"),
+    cursor.eventIndex,
+  ].join(":");
+}

--- a/packages/starknet-rpc/src/cursor.ts
+++ b/packages/starknet-rpc/src/cursor.ts
@@ -14,19 +14,6 @@ export function compareEventCursor(a: EventCursor, b: EventCursor): number {
     return a.eventIndex < b.eventIndex ? -1 : 1;
   }
 
-  const aTransactionHash = normalizeFelt(
-    a.transactionHash,
-    "cursor.transactionHash",
-  );
-  const bTransactionHash = normalizeFelt(
-    b.transactionHash,
-    "cursor.transactionHash",
-  );
-
-  if (aTransactionHash !== bTransactionHash) {
-    return aTransactionHash < bTransactionHash ? -1 : 1;
-  }
-
   return 0;
 }
 

--- a/packages/starknet-rpc/src/cursor.ts
+++ b/packages/starknet-rpc/src/cursor.ts
@@ -6,6 +6,14 @@ export function compareEventCursor(a: EventCursor, b: EventCursor): number {
     return a.blockNumber < b.blockNumber ? -1 : 1;
   }
 
+  if (a.transactionIndex !== b.transactionIndex) {
+    return a.transactionIndex < b.transactionIndex ? -1 : 1;
+  }
+
+  if (a.eventIndex !== b.eventIndex) {
+    return a.eventIndex < b.eventIndex ? -1 : 1;
+  }
+
   const aTransactionHash = normalizeFelt(
     a.transactionHash,
     "cursor.transactionHash",
@@ -17,10 +25,6 @@ export function compareEventCursor(a: EventCursor, b: EventCursor): number {
 
   if (aTransactionHash !== bTransactionHash) {
     return aTransactionHash < bTransactionHash ? -1 : 1;
-  }
-
-  if (a.eventIndex !== b.eventIndex) {
-    return a.eventIndex < b.eventIndex ? -1 : 1;
   }
 
   return 0;

--- a/packages/starknet-rpc/src/http.ts
+++ b/packages/starknet-rpc/src/http.ts
@@ -36,7 +36,7 @@ interface JsonRpcResponse<T> {
 interface StarknetGetEventsFilter {
   from_block?: GetEventsOptions["fromBlock"];
   to_block?: GetEventsOptions["toBlock"];
-  address?: Felt;
+  address?: Felt | Felt[];
   keys?: Felt[][];
   chunk_size?: number;
   continuation_token?: string;
@@ -257,8 +257,8 @@ function buildGetEventsParams(
     filter.to_block = options.toBlock;
   }
 
-  if (addresses?.length === 1) {
-    filter.address = addresses[0];
+  if (addresses !== undefined) {
+    filter.address = addresses.length === 1 ? addresses[0] : addresses;
   }
 
   if (keys !== undefined) {

--- a/packages/starknet-rpc/src/http.ts
+++ b/packages/starknet-rpc/src/http.ts
@@ -36,7 +36,7 @@ interface JsonRpcResponse<T> {
 interface StarknetGetEventsFilter {
   from_block?: GetEventsOptions["fromBlock"];
   to_block?: GetEventsOptions["toBlock"];
-  address?: Felt | Felt[];
+  address?: Felt;
   keys?: Felt[][];
   chunk_size?: number;
   continuation_token?: string;
@@ -60,6 +60,7 @@ interface TransportContext extends RpcContext {
 }
 
 let nextJsonRpcId = 1;
+const DEFAULT_GET_EVENTS_CHUNK_SIZE = 100;
 
 export class StarknetRpcError extends Error {
   code: number;
@@ -256,17 +257,15 @@ function buildGetEventsParams(
     filter.to_block = options.toBlock;
   }
 
-  if (addresses !== undefined) {
-    filter.address = addresses.length === 1 ? addresses[0] : addresses;
+  if (addresses?.length === 1) {
+    filter.address = addresses[0];
   }
 
   if (keys !== undefined) {
     filter.keys = keys;
   }
 
-  if (options.chunkSize !== undefined) {
-    filter.chunk_size = options.chunkSize;
-  }
+  filter.chunk_size = options.chunkSize ?? DEFAULT_GET_EVENTS_CHUNK_SIZE;
 
   if (options.continuationToken !== undefined) {
     filter.continuation_token = options.continuationToken;

--- a/packages/starknet-rpc/src/http.ts
+++ b/packages/starknet-rpc/src/http.ts
@@ -136,32 +136,39 @@ export async function jsonRpc<T>(
     ...(call.params !== undefined ? { params: call.params } : {}),
   };
 
+  const requestSignal = createRequestAbortSignal(call.signal);
   let response: Response;
+  let body: string;
   try {
-    response = await fetch(call.url, {
-      method: "POST",
-      headers: {
-        accept: "application/json",
-        "content-type": "application/json",
-      },
-      body: JSON.stringify(request),
-      signal: call.signal,
-    });
-  } catch (error) {
-    if (isAbortError(error)) {
-      throw error;
+    try {
+      response = await fetch(call.url, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(request),
+        signal: requestSignal.signal,
+      });
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw error;
+      }
+
+      throw new StarknetTransportError(
+        `Failed to send JSON-RPC request to ${call.url}`,
+        {
+          ...context,
+          cause: error,
+        },
+      );
     }
 
-    throw new StarknetTransportError(
-      `Failed to send JSON-RPC request to ${call.url}`,
-      {
-        ...context,
-        cause: error,
-      },
-    );
+    body = await response.text();
+  } finally {
+    requestSignal.cleanup();
   }
 
-  const body = await response.text();
   const parsed = parseJsonRpcResponse<T>(body);
 
   if (!response.ok) {
@@ -360,6 +367,31 @@ function isAbortSignal(value: unknown): value is AbortSignal {
     typeof value.aborted === "boolean" &&
     typeof value.addEventListener === "function"
   );
+}
+
+function createRequestAbortSignal(signal: AbortSignal | undefined): {
+  signal?: AbortSignal;
+  cleanup(): void;
+} {
+  if (!signal) {
+    return { signal: undefined, cleanup() {} };
+  }
+
+  const controller = new AbortController();
+  if (signal.aborted) {
+    controller.abort(signal.reason);
+    return { signal: controller.signal, cleanup() {} };
+  }
+
+  const abort = () => controller.abort(signal.reason);
+  signal.addEventListener("abort", abort, { once: true });
+
+  return {
+    signal: controller.signal,
+    cleanup() {
+      signal.removeEventListener("abort", abort);
+    },
+  };
 }
 
 function bodySnippet(body: string): string | undefined {

--- a/packages/starknet-rpc/src/http.ts
+++ b/packages/starknet-rpc/src/http.ts
@@ -1,0 +1,374 @@
+import { matchesEventFilter, normalizeEvent, normalizeFelt } from "./normalize";
+import type {
+  EventFilter,
+  Felt,
+  GetEventsOptions,
+  GetEventsPage,
+  RpcEvent,
+} from "./types";
+
+type JsonRpcId = number | string | null;
+
+interface JsonRpcRequestOptions {
+  id?: JsonRpcId;
+  signal?: AbortSignal;
+}
+
+interface JsonRpcCallOptions extends JsonRpcRequestOptions {
+  url: string;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcErrorPayload {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+interface JsonRpcResponse<T> {
+  jsonrpc?: string;
+  id?: JsonRpcId;
+  result?: T;
+  error?: JsonRpcErrorPayload;
+}
+
+interface StarknetGetEventsParams {
+  filter: {
+    from_block?: GetEventsOptions["fromBlock"];
+    to_block?: GetEventsOptions["toBlock"];
+    address?: Felt | Felt[];
+    keys?: Felt[][];
+    chunk_size?: number;
+    continuation_token?: string;
+  };
+}
+
+interface StarknetGetEventsResult {
+  events: RpcEvent[];
+  continuation_token?: string;
+}
+
+interface RpcContext {
+  url: string;
+  method: string;
+}
+
+interface TransportContext extends RpcContext {
+  status?: number;
+  statusText?: string;
+  body?: string;
+  cause?: unknown;
+}
+
+let nextJsonRpcId = 1;
+
+export class StarknetRpcError extends Error {
+  code: number;
+  data?: unknown;
+  method: string;
+  url: string;
+
+  constructor(error: JsonRpcErrorPayload, context: RpcContext) {
+    super(
+      `Starknet RPC error ${error.code} from ${context.method}: ${error.message}`,
+    );
+    this.name = "StarknetRpcError";
+    this.code = error.code;
+    this.data = error.data;
+    this.method = context.method;
+    this.url = context.url;
+  }
+}
+
+export class StarknetTransportError extends Error {
+  status?: number;
+  statusText?: string;
+  body?: string;
+  cause?: unknown;
+  method: string;
+  url: string;
+
+  constructor(message: string, context: TransportContext) {
+    super(message);
+    this.name = "StarknetTransportError";
+    this.status = context.status;
+    this.statusText = context.statusText;
+    this.body = context.body;
+    this.cause = context.cause;
+    this.method = context.method;
+    this.url = context.url;
+  }
+}
+
+export function jsonRpc<T>(options: JsonRpcCallOptions): Promise<T>;
+export function jsonRpc<T>(
+  url: string,
+  method: string,
+  params?: unknown,
+  options?: JsonRpcRequestOptions | AbortSignal,
+): Promise<T>;
+export async function jsonRpc<T>(
+  urlOrOptions: string | JsonRpcCallOptions,
+  methodArg?: string,
+  paramsArg?: unknown,
+  optionsArg: JsonRpcRequestOptions | AbortSignal = {},
+): Promise<T> {
+  const requestOptions = normalizeRequestOptions(optionsArg);
+  const call =
+    typeof urlOrOptions === "string"
+      ? {
+          ...requestOptions,
+          url: urlOrOptions,
+          method: methodArg,
+          params: paramsArg,
+        }
+      : urlOrOptions;
+
+  if (!call.method) {
+    throw new TypeError("jsonRpc requires a method");
+  }
+
+  const context = { url: call.url, method: call.method };
+  const request = {
+    jsonrpc: "2.0",
+    id: call.id ?? nextJsonRpcId++,
+    method: call.method,
+    ...(call.params !== undefined ? { params: call.params } : {}),
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(call.url, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(request),
+      signal: call.signal,
+    });
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
+
+    throw new StarknetTransportError(
+      `Failed to send JSON-RPC request to ${call.url}`,
+      {
+        ...context,
+        cause: error,
+      },
+    );
+  }
+
+  const body = await response.text();
+  const parsed = parseJsonRpcResponse<T>(body);
+
+  if (!response.ok) {
+    const rpcError = parsed ? normalizeRpcError(parsed.error) : undefined;
+    if (rpcError) {
+      throw new StarknetRpcError(rpcError, context);
+    }
+
+    throw new StarknetTransportError(
+      `JSON-RPC request to ${call.url} failed with HTTP ${response.status}`,
+      {
+        ...context,
+        status: response.status,
+        statusText: response.statusText,
+        body: bodySnippet(body),
+      },
+    );
+  }
+
+  if (!parsed) {
+    throw new StarknetTransportError("Invalid JSON-RPC response", {
+      ...context,
+      body: bodySnippet(body),
+    });
+  }
+
+  const rpcError = normalizeRpcError(parsed.error);
+  if (rpcError) {
+    throw new StarknetRpcError(rpcError, context);
+  }
+
+  if (!("result" in parsed)) {
+    throw new StarknetTransportError("JSON-RPC response is missing result", {
+      ...context,
+      body: bodySnippet(body),
+    });
+  }
+
+  return parsed.result as T;
+}
+
+export async function getEvents(
+  options: GetEventsOptions,
+): Promise<GetEventsPage> {
+  const addresses = normalizeFelts(options.addresses);
+  const keys = normalizeKeys(options.keys);
+  const params = buildGetEventsParams(options, addresses, keys);
+
+  const result = await jsonRpc<StarknetGetEventsResult>({
+    url: options.url,
+    method: "starknet_getEvents",
+    params,
+    signal: options.signal,
+  });
+
+  if (!result || !Array.isArray(result.events)) {
+    throw new StarknetTransportError("Invalid starknet_getEvents response", {
+      url: options.url,
+      method: "starknet_getEvents",
+    });
+  }
+
+  const clientFilter: EventFilter = {
+    addresses,
+    keys,
+  };
+  const shouldFilterClientSide = Boolean(addresses || keys);
+  const events = result.events
+    .map((event) => normalizeEvent(event))
+    .filter(
+      (event) =>
+        !shouldFilterClientSide || matchesEventFilter(event, clientFilter),
+    );
+
+  return {
+    events,
+    continuationToken: result.continuation_token,
+  };
+}
+
+function buildGetEventsParams(
+  options: GetEventsOptions,
+  addresses: Felt[] | undefined,
+  keys: Felt[][] | undefined,
+): StarknetGetEventsParams {
+  const filter: StarknetGetEventsParams["filter"] = {};
+
+  if (options.fromBlock !== undefined) {
+    filter.from_block = options.fromBlock;
+  }
+
+  if (options.toBlock !== undefined) {
+    filter.to_block = options.toBlock;
+  }
+
+  if (addresses !== undefined) {
+    filter.address = addresses.length === 1 ? addresses[0] : addresses;
+  }
+
+  if (keys !== undefined) {
+    filter.keys = keys;
+  }
+
+  if (options.chunkSize !== undefined) {
+    filter.chunk_size = options.chunkSize;
+  }
+
+  if (options.continuationToken !== undefined) {
+    filter.continuation_token = options.continuationToken;
+  }
+
+  return { filter };
+}
+
+function normalizeFelts(values: Felt[] | undefined): Felt[] | undefined {
+  if (!values || values.length === 0) {
+    return undefined;
+  }
+
+  return values.map((value) => normalizeFelt(value));
+}
+
+function normalizeKeys(keys: Felt[][] | undefined): Felt[][] | undefined {
+  if (!keys || keys.length === 0) {
+    return undefined;
+  }
+
+  return keys.map((values) => values.map((value) => normalizeFelt(value)));
+}
+
+function parseJsonRpcResponse<T>(body: string): JsonRpcResponse<T> | undefined {
+  if (body.trim() === "") {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    if (!isRecord(parsed)) {
+      return undefined;
+    }
+
+    return parsed as JsonRpcResponse<T>;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeRpcError(
+  error: JsonRpcResponse<unknown>["error"],
+): JsonRpcErrorPayload | undefined {
+  if (error === undefined) {
+    return undefined;
+  }
+
+  if (isRecord(error)) {
+    return {
+      code: typeof error.code === "number" ? error.code : -32000,
+      message:
+        typeof error.message === "string"
+          ? error.message
+          : "Unknown Starknet RPC error",
+      data: error.data,
+    };
+  }
+
+  return {
+    code: -32000,
+    message: "Unknown Starknet RPC error",
+    data: error,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    isRecord(error) &&
+    typeof error.name === "string" &&
+    error.name === "AbortError"
+  );
+}
+
+function normalizeRequestOptions(
+  options: JsonRpcRequestOptions | AbortSignal,
+): JsonRpcRequestOptions {
+  if (isAbortSignal(options)) {
+    return { signal: options };
+  }
+
+  return options;
+}
+
+function isAbortSignal(value: unknown): value is AbortSignal {
+  return (
+    isRecord(value) &&
+    typeof value.aborted === "boolean" &&
+    typeof value.addEventListener === "function"
+  );
+}
+
+function bodySnippet(body: string): string | undefined {
+  if (body.length === 0) {
+    return undefined;
+  }
+
+  return body.length > 500 ? `${body.slice(0, 500)}...` : body;
+}

--- a/packages/starknet-rpc/src/http.ts
+++ b/packages/starknet-rpc/src/http.ts
@@ -33,15 +33,13 @@ interface JsonRpcResponse<T> {
   error?: JsonRpcErrorPayload;
 }
 
-interface StarknetGetEventsParams {
-  filter: {
-    from_block?: GetEventsOptions["fromBlock"];
-    to_block?: GetEventsOptions["toBlock"];
-    address?: Felt | Felt[];
-    keys?: Felt[][];
-    chunk_size?: number;
-    continuation_token?: string;
-  };
+interface StarknetGetEventsFilter {
+  from_block?: GetEventsOptions["fromBlock"];
+  to_block?: GetEventsOptions["toBlock"];
+  address?: Felt | Felt[];
+  keys?: Felt[][];
+  chunk_size?: number;
+  continuation_token?: string;
 }
 
 interface StarknetGetEventsResult {
@@ -214,7 +212,7 @@ export async function getEvents(
   const result = await jsonRpc<StarknetGetEventsResult>({
     url: options.url,
     method: "starknet_getEvents",
-    params,
+    params: [params],
     signal: options.signal,
   });
 
@@ -247,8 +245,8 @@ function buildGetEventsParams(
   options: GetEventsOptions,
   addresses: Felt[] | undefined,
   keys: Felt[][] | undefined,
-): StarknetGetEventsParams {
-  const filter: StarknetGetEventsParams["filter"] = {};
+): StarknetGetEventsFilter {
+  const filter: StarknetGetEventsFilter = {};
 
   if (options.fromBlock !== undefined) {
     filter.from_block = options.fromBlock;
@@ -274,7 +272,7 @@ function buildGetEventsParams(
     filter.continuation_token = options.continuationToken;
   }
 
-  return { filter };
+  return filter;
 }
 
 function normalizeFelts(values: Felt[] | undefined): Felt[] | undefined {

--- a/packages/starknet-rpc/src/index.ts
+++ b/packages/starknet-rpc/src/index.ts
@@ -7,7 +7,9 @@ export { backfillEvents } from "./backfill";
 export {
   compareEventCursor,
   cursorEquals,
+  cursorBeforeBlock,
   eventCursorKey,
+  isCursorBeforeBlock,
 } from "./cursor";
 export {
   StarknetRpcError,

--- a/packages/starknet-rpc/src/index.ts
+++ b/packages/starknet-rpc/src/index.ts
@@ -18,6 +18,7 @@ export {
   jsonRpc,
 } from "./http";
 export {
+  StarknetEventCursorError,
   matchesEventFilter,
   normalizeEvent,
   normalizeFelt,
@@ -34,6 +35,8 @@ export type {
 export { subscribeEvents } from "./subscribe";
 export {
   TooManyBlocksBackError,
+  WebSocketIdleTimeoutError,
+  WebSocketQueueOverflowError,
   connectSubscribeEvents,
 } from "./ws";
 export type {

--- a/packages/starknet-rpc/src/index.ts
+++ b/packages/starknet-rpc/src/index.ts
@@ -49,6 +49,8 @@ export type {
   RpcWebSocket,
   StreamEventsOptions,
   StreamMessage,
+  SubscriptionBlockId,
+  SubscriptionFinalityStatus,
   SubscribeEventsOptions,
   SubscribeReconnectOptions,
   WebSocketFactory,

--- a/packages/starknet-rpc/src/index.ts
+++ b/packages/starknet-rpc/src/index.ts
@@ -1,0 +1,55 @@
+export {
+  StarknetBlockCache,
+  getBlockWithTxHashes,
+  getLatestBlock,
+} from "./block-cache";
+export { backfillEvents } from "./backfill";
+export {
+  compareEventCursor,
+  cursorEquals,
+  eventCursorKey,
+} from "./cursor";
+export {
+  StarknetRpcError,
+  StarknetTransportError,
+  getEvents,
+  jsonRpc,
+} from "./http";
+export {
+  matchesEventFilter,
+  normalizeEvent,
+  normalizeFelt,
+  normalizeReorg,
+} from "./normalize";
+export { streamEvents } from "./stream";
+export { subscribeEvents } from "./subscribe";
+export {
+  TooManyBlocksBackError,
+  connectSubscribeEvents,
+} from "./ws";
+export type {
+  BackfillEventsOptions,
+  BlockCacheOptions,
+  BlockId,
+  BlockMetadata,
+  BlockTag,
+  EventCursor,
+  EventFilter,
+  EventMessage,
+  EventSubscription,
+  Felt,
+  FinalityStatus,
+  GetEventsOptions,
+  GetEventsPage,
+  NormalizedEvent,
+  NormalizedReorg,
+  ReorgMessage,
+  RpcEvent,
+  RpcReorg,
+  RpcWebSocket,
+  StreamEventsOptions,
+  StreamMessage,
+  SubscribeEventsOptions,
+  SubscribeReconnectOptions,
+  WebSocketFactory,
+} from "./types";

--- a/packages/starknet-rpc/src/index.ts
+++ b/packages/starknet-rpc/src/index.ts
@@ -24,6 +24,13 @@ export {
   normalizeReorg,
 } from "./normalize";
 export { streamEvents } from "./stream";
+export { StarknetRpcStream } from "./stream-config";
+export type {
+  StarknetRpcBlock,
+  StarknetRpcBlockHeader,
+  StarknetRpcStreamFilter,
+  StarknetRpcStreamOptions,
+} from "./stream-config";
 export { subscribeEvents } from "./subscribe";
 export {
   TooManyBlocksBackError,

--- a/packages/starknet-rpc/src/normalize.ts
+++ b/packages/starknet-rpc/src/normalize.ts
@@ -1,0 +1,271 @@
+import type {
+  BlockId,
+  EventFilter,
+  Felt,
+  NormalizedEvent,
+  NormalizedReorg,
+  RpcEvent,
+  RpcReorg,
+} from "./types";
+
+const FELT_HEX_LENGTH = 64;
+
+export function normalizeFelt(value: Felt, field = "felt"): Felt {
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be a 0x-prefixed hex string`);
+  }
+
+  if (!value.startsWith("0x") && !value.startsWith("0X")) {
+    throw new Error(`${field} must be a 0x-prefixed hex string`);
+  }
+
+  const hex = value.slice(2).toLowerCase();
+
+  if (hex.length === 0) {
+    throw new Error(`${field} must contain at least one hex digit`);
+  }
+
+  if (!/^[0-9a-f]+$/.test(hex)) {
+    throw new Error(`${field} must contain only hex digits`);
+  }
+
+  if (hex.length > FELT_HEX_LENGTH) {
+    throw new Error(`${field} exceeds ${FELT_HEX_LENGTH} hex digits`);
+  }
+
+  return `0x${hex.padStart(FELT_HEX_LENGTH, "0")}`;
+}
+
+export function normalizeEvent(raw: RpcEvent): NormalizedEvent {
+  const blockNumber = requiredNonNegativeInteger(
+    raw.block_number,
+    "event.block_number",
+  );
+  const transactionHash = normalizeFelt(
+    requiredFelt(raw.transaction_hash, "event.transaction_hash"),
+    "event.transaction_hash",
+  );
+  const eventIndex = requiredNonNegativeInteger(
+    raw.event_index,
+    "event.event_index",
+  );
+
+  const transactionIndex =
+    raw.transaction_index === undefined
+      ? undefined
+      : requiredNonNegativeInteger(
+          raw.transaction_index,
+          "event.transaction_index",
+        );
+
+  const blockHash =
+    raw.block_hash === undefined
+      ? undefined
+      : normalizeFelt(raw.block_hash, "event.block_hash");
+
+  return {
+    cursor: {
+      blockNumber,
+      transactionHash,
+      eventIndex,
+    },
+    fromAddress: normalizeFelt(
+      requiredFelt(raw.from_address, "event.from_address"),
+      "event.from_address",
+    ),
+    keys: requiredFeltArray(raw.keys, "event.keys"),
+    data: requiredFeltArray(raw.data, "event.data"),
+    blockHash,
+    blockNumber,
+    transactionHash,
+    transactionIndex,
+    eventIndex,
+    finalityStatus: raw.finality_status,
+    raw,
+  };
+}
+
+export function normalizeReorg(raw: RpcReorg): NormalizedReorg {
+  return {
+    startingBlockNumber: requiredNonNegativeInteger(
+      raw.starting_block_number,
+      "reorg.starting_block_number",
+    ),
+    startingBlockHash: normalizeFelt(
+      requiredFelt(raw.starting_block_hash, "reorg.starting_block_hash"),
+      "reorg.starting_block_hash",
+    ),
+    endingBlockNumber: requiredNonNegativeInteger(
+      raw.ending_block_number,
+      "reorg.ending_block_number",
+    ),
+    endingBlockHash: normalizeFelt(
+      requiredFelt(raw.ending_block_hash, "reorg.ending_block_hash"),
+      "reorg.ending_block_hash",
+    ),
+    raw,
+  };
+}
+
+export function matchesEventFilter(
+  event: NormalizedEvent | RpcEvent,
+  filter: EventFilter,
+): boolean {
+  if (!matchesBlockFilter(event, filter.fromBlock, filter.toBlock)) {
+    return false;
+  }
+
+  if (filter.addresses && filter.addresses.length > 0) {
+    const eventAddress = normalizeFelt(getEventAddress(event), "event address");
+    const addresses = new Set(
+      filter.addresses.map((address) =>
+        normalizeFelt(address, "filter.addresses"),
+      ),
+    );
+
+    if (!addresses.has(eventAddress)) {
+      return false;
+    }
+  }
+
+  if (filter.keys && filter.keys.length > 0) {
+    for (let position = 0; position < filter.keys.length; position++) {
+      const expectedKeys = filter.keys[position];
+
+      if (!expectedKeys || expectedKeys.length === 0) {
+        continue;
+      }
+
+      const eventKey = event.keys[position];
+      if (eventKey === undefined) {
+        return false;
+      }
+
+      const normalizedEventKey = normalizeFelt(
+        eventKey,
+        `event.keys[${position}]`,
+      );
+      const normalizedExpectedKeys = new Set(
+        expectedKeys.map((key) =>
+          normalizeFelt(key, `filter.keys[${position}]`),
+        ),
+      );
+
+      if (!normalizedExpectedKeys.has(normalizedEventKey)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+function requiredFelt(value: unknown, field: string): Felt {
+  if (typeof value !== "string") {
+    throw new Error(`${field} is required`);
+  }
+
+  return value;
+}
+
+function requiredFeltArray(value: unknown, field: string): Felt[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${field} is required`);
+  }
+
+  return value.map((felt, index) =>
+    normalizeFelt(
+      requiredFelt(felt, `${field}[${index}]`),
+      `${field}[${index}]`,
+    ),
+  );
+}
+
+function requiredNonNegativeInteger(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new Error(`${field} is required and must be a non-negative integer`);
+  }
+
+  return value;
+}
+
+function getEventAddress(event: NormalizedEvent | RpcEvent): Felt {
+  return isNormalizedEvent(event) ? event.fromAddress : event.from_address;
+}
+
+function getEventBlockNumber(event: NormalizedEvent | RpcEvent): number {
+  return isNormalizedEvent(event)
+    ? event.blockNumber
+    : requiredNonNegativeInteger(event.block_number, "event.block_number");
+}
+
+function getEventBlockHash(
+  event: NormalizedEvent | RpcEvent,
+): Felt | undefined {
+  const blockHash = isNormalizedEvent(event)
+    ? event.blockHash
+    : event.block_hash;
+  return blockHash === undefined
+    ? undefined
+    : normalizeFelt(blockHash, "event.block_hash");
+}
+
+function isNormalizedEvent(
+  event: NormalizedEvent | RpcEvent,
+): event is NormalizedEvent {
+  return "fromAddress" in event;
+}
+
+function matchesBlockFilter(
+  event: NormalizedEvent | RpcEvent,
+  fromBlock?: BlockId,
+  toBlock?: BlockId,
+): boolean {
+  if (isBlockNumberId(fromBlock) || isBlockNumberId(toBlock)) {
+    const blockNumber = getEventBlockNumber(event);
+
+    if (isBlockNumberId(fromBlock) && blockNumber < fromBlock.block_number) {
+      return false;
+    }
+
+    if (isBlockNumberId(toBlock) && blockNumber > toBlock.block_number) {
+      return false;
+    }
+  }
+
+  if (isBlockHashId(fromBlock) || isBlockHashId(toBlock)) {
+    const blockHash = getEventBlockHash(event);
+
+    if (
+      isBlockHashId(fromBlock) &&
+      blockHash !== normalizeFelt(fromBlock.block_hash, "filter.fromBlock")
+    ) {
+      return false;
+    }
+
+    if (
+      isBlockHashId(toBlock) &&
+      blockHash !== normalizeFelt(toBlock.block_hash, "filter.toBlock")
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isBlockNumberId(
+  blockId: BlockId | undefined,
+): blockId is { block_number: number } {
+  return (
+    typeof blockId === "object" && blockId !== null && "block_number" in blockId
+  );
+}
+
+function isBlockHashId(
+  blockId: BlockId | undefined,
+): blockId is { block_hash: Felt } {
+  return (
+    typeof blockId === "object" && blockId !== null && "block_hash" in blockId
+  );
+}

--- a/packages/starknet-rpc/src/normalize.ts
+++ b/packages/starknet-rpc/src/normalize.ts
@@ -49,14 +49,10 @@ export function normalizeEvent(raw: RpcEvent): NormalizedEvent {
     raw.event_index,
     "event.event_index",
   );
-
-  const transactionIndex =
-    raw.transaction_index === undefined
-      ? undefined
-      : requiredNonNegativeInteger(
-          raw.transaction_index,
-          "event.transaction_index",
-        );
+  const transactionIndex = requiredNonNegativeInteger(
+    raw.transaction_index,
+    "event.transaction_index",
+  );
 
   const blockHash =
     raw.block_hash === undefined
@@ -66,6 +62,7 @@ export function normalizeEvent(raw: RpcEvent): NormalizedEvent {
   return {
     cursor: {
       blockNumber,
+      transactionIndex,
       transactionHash,
       eventIndex,
     },

--- a/packages/starknet-rpc/src/normalize.ts
+++ b/packages/starknet-rpc/src/normalize.ts
@@ -10,7 +10,14 @@ import type {
 
 const FELT_HEX_LENGTH = 64;
 const EVENT_CURSOR_FIELD_REQUIREMENT =
-  "This package requires Starknet JSON-RPC >= 0.10 event cursor fields: block_number, transaction_index, and event_index.";
+  "This package requires Starknet event payloads to include block_number, transaction_index, and event_index for duplicate-safe cursoring. Use a Starknet JSON-RPC >= 0.10 endpoint that provides these fields.";
+
+export class StarknetEventCursorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StarknetEventCursorError";
+  }
+}
 
 export function normalizeFelt(value: Felt, field = "felt"): Felt {
   if (typeof value !== "string") {
@@ -189,11 +196,15 @@ function requiredNonNegativeInteger(
   requirement?: string,
 ): number {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
-    throw new Error(
-      `${field} is required and must be a non-negative integer${
-        requirement ? `. ${requirement}` : ""
-      }`,
-    );
+    const message = `${field} is required and must be a non-negative integer${
+      requirement ? `. ${requirement}` : ""
+    }`;
+
+    if (requirement) {
+      throw new StarknetEventCursorError(message);
+    }
+
+    throw new Error(message);
   }
 
   return value;

--- a/packages/starknet-rpc/src/normalize.ts
+++ b/packages/starknet-rpc/src/normalize.ts
@@ -9,6 +9,8 @@ import type {
 } from "./types";
 
 const FELT_HEX_LENGTH = 64;
+const EVENT_CURSOR_FIELD_REQUIREMENT =
+  "This package requires Starknet JSON-RPC >= 0.10 event cursor fields: block_number, transaction_index, and event_index.";
 
 export function normalizeFelt(value: Felt, field = "felt"): Felt {
   if (typeof value !== "string") {
@@ -40,6 +42,7 @@ export function normalizeEvent(raw: RpcEvent): NormalizedEvent {
   const blockNumber = requiredNonNegativeInteger(
     raw.block_number,
     "event.block_number",
+    EVENT_CURSOR_FIELD_REQUIREMENT,
   );
   const transactionHash = normalizeFelt(
     requiredFelt(raw.transaction_hash, "event.transaction_hash"),
@@ -48,10 +51,12 @@ export function normalizeEvent(raw: RpcEvent): NormalizedEvent {
   const eventIndex = requiredNonNegativeInteger(
     raw.event_index,
     "event.event_index",
+    EVENT_CURSOR_FIELD_REQUIREMENT,
   );
   const transactionIndex = requiredNonNegativeInteger(
     raw.transaction_index,
     "event.transaction_index",
+    EVENT_CURSOR_FIELD_REQUIREMENT,
   );
 
   const blockHash =
@@ -178,9 +183,17 @@ function requiredFeltArray(value: unknown, field: string): Felt[] {
   );
 }
 
-function requiredNonNegativeInteger(value: unknown, field: string): number {
+function requiredNonNegativeInteger(
+  value: unknown,
+  field: string,
+  requirement?: string,
+): number {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
-    throw new Error(`${field} is required and must be a non-negative integer`);
+    throw new Error(
+      `${field} is required and must be a non-negative integer${
+        requirement ? `. ${requirement}` : ""
+      }`,
+    );
   }
 
   return value;

--- a/packages/starknet-rpc/src/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/src/starknet-rpc.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { backfillEvents } from "./backfill";
 import { getBlockWithTxHashes } from "./block-cache";
-import { compareEventCursor } from "./cursor";
+import { compareEventCursor, eventCursorKey } from "./cursor";
 import { getEvents } from "./http";
-import { normalizeFelt } from "./normalize";
+import { normalizeEvent, normalizeFelt } from "./normalize";
 import { streamEvents } from "./stream";
 import { subscribeEvents } from "./subscribe";
 import type { EventCursor, RpcEvent } from "./types";
@@ -25,16 +25,43 @@ describe("felt normalization", () => {
 });
 
 describe("cursor comparison", () => {
-  it("orders by block number, transaction hash, and per-transaction event index", () => {
+  it("orders by block number, transaction index, and per-transaction event index", () => {
     expect(
-      compareEventCursor(cursor(1, "0x2", 0), cursor(2, "0x1", 0)),
+      compareEventCursor(cursor(1, "0x2", 0, 0), cursor(2, "0x1", 0, 0)),
     ).toBeLessThan(0);
     expect(
-      compareEventCursor(cursor(2, "0x1", 1), cursor(2, "0x2", 0)),
+      compareEventCursor(cursor(2, "0xff", 0, 0), cursor(2, "0x1", 1, 0)),
     ).toBeLessThan(0);
     expect(
-      compareEventCursor(cursor(2, "0x2", 1), cursor(2, "0x2", 0)),
+      compareEventCursor(cursor(2, "0x2", 1, 1), cursor(2, "0x2", 1, 0)),
     ).toBeGreaterThan(0);
+    expect(
+      compareEventCursor(cursor(2, "0x2", 1, 0), cursor(2, "0x1", 1, 0)),
+    ).toBeGreaterThan(0);
+  });
+
+  it("keeps the cursor identity keyed by transaction hash and event index", () => {
+    expect(eventCursorKey(cursor(5, "0xabc", 1, 2))).toBe(
+      eventCursorKey(cursor(5, "0x0abc", 99, 2)),
+    );
+  });
+});
+
+describe("event normalization", () => {
+  it("requires transaction_index and includes it in the cursor", () => {
+    expect(normalizeEvent(rawEvent({ transactionIndex: 7 })).cursor).toEqual({
+      blockNumber: 1,
+      transactionIndex: 7,
+      transactionHash: normalizeFelt("0x1"),
+      eventIndex: 0,
+    });
+
+    const { transaction_index: _transactionIndex, ...missingTransactionIndex } =
+      rawEvent();
+
+    expect(() => normalizeEvent(missingTransactionIndex)).toThrow(
+      /event\.transaction_index/,
+    );
   });
 });
 
@@ -156,15 +183,30 @@ describe("HTTP backfill", () => {
 
   it("resumes from a persisted cursor and skips replayed events", async () => {
     const requests: unknown[] = [];
-    const resumeCursor = cursor(5, "0x2", 1);
+    const resumeCursor = cursor(5, "0x2", 1, 1);
 
     mockRpcFetch((request) => {
       requests.push(request);
       return {
         events: [
-          rawEvent({ blockNumber: 5, transactionHash: "0x1", eventIndex: 0 }),
-          rawEvent({ blockNumber: 5, transactionHash: "0x2", eventIndex: 1 }),
-          rawEvent({ blockNumber: 5, transactionHash: "0x3", eventIndex: 0 }),
+          rawEvent({
+            blockNumber: 5,
+            transactionHash: "0x1",
+            transactionIndex: 0,
+            eventIndex: 0,
+          }),
+          rawEvent({
+            blockNumber: 5,
+            transactionHash: "0x2",
+            transactionIndex: 1,
+            eventIndex: 1,
+          }),
+          rawEvent({
+            blockNumber: 5,
+            transactionHash: "0x3",
+            transactionIndex: 2,
+            eventIndex: 0,
+          }),
         ],
       };
     });
@@ -181,6 +223,7 @@ describe("HTTP backfill", () => {
     expect(messages).toHaveLength(1);
     expect(messages[0].cursor).toMatchObject({
       blockNumber: 5,
+      transactionIndex: 2,
       transactionHash: normalizeFelt("0x3"),
       eventIndex: 0,
     });
@@ -416,9 +459,10 @@ function singleParam(request: JsonRpcRequest): Record<string, unknown> {
 function cursor(
   blockNumber: number,
   transactionHash = "0x1",
+  transactionIndex = 0,
   eventIndex = 0,
 ): EventCursor {
-  return { blockNumber, transactionHash, eventIndex };
+  return { blockNumber, transactionIndex, transactionHash, eventIndex };
 }
 
 function rawEvent({

--- a/packages/starknet-rpc/src/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/src/starknet-rpc.test.ts
@@ -1,0 +1,521 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { backfillEvents } from "./backfill";
+import { compareEventCursor } from "./cursor";
+import { normalizeFelt } from "./normalize";
+import { streamEvents } from "./stream";
+import { subscribeEvents } from "./subscribe";
+import type { EventCursor, RpcEvent } from "./types";
+import { TooManyBlocksBackError, connectSubscribeEvents } from "./ws";
+
+const RPC_URL = "http://example.test/rpc";
+const WS_URL = "ws://example.test/rpc";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("felt normalization", () => {
+  it("pads felts to canonical Starknet hex", () => {
+    expect(normalizeFelt("0xAbC")).toBe(`0x${"0".repeat(61)}abc`);
+    expect(() => normalizeFelt("abc")).toThrow(/0x-prefixed/);
+  });
+});
+
+describe("cursor comparison", () => {
+  it("orders by block number, transaction hash, and per-transaction event index", () => {
+    expect(
+      compareEventCursor(cursor(1, "0x2", 0), cursor(2, "0x1", 0)),
+    ).toBeLessThan(0);
+    expect(
+      compareEventCursor(cursor(2, "0x1", 1), cursor(2, "0x2", 0)),
+    ).toBeLessThan(0);
+    expect(
+      compareEventCursor(cursor(2, "0x2", 1), cursor(2, "0x2", 0)),
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("HTTP backfill", () => {
+  it("follows continuation tokens without skipping pages", async () => {
+    const requests: unknown[] = [];
+    mockRpcFetch((request) => {
+      requests.push(request);
+
+      if (request.method !== "starknet_getEvents") {
+        throw new Error(`unexpected method ${request.method}`);
+      }
+
+      if (!request.params.filter.continuation_token) {
+        return {
+          events: [
+            rawEvent({ blockNumber: 1, transactionHash: "0x1", eventIndex: 0 }),
+            rawEvent({ blockNumber: 1, transactionHash: "0x2", eventIndex: 0 }),
+          ],
+          continuation_token: "page-2",
+        };
+      }
+
+      return {
+        events: [
+          rawEvent({ blockNumber: 2, transactionHash: "0x1", eventIndex: 0 }),
+        ],
+      };
+    });
+
+    const messages = await collect(
+      backfillEvents({
+        url: RPC_URL,
+        fromBlock: { block_number: 1 },
+        toBlock: { block_number: 2 },
+        chunkSize: 2,
+      }),
+    );
+
+    expect(messages.map((message) => message.cursor.blockNumber)).toEqual([
+      1, 1, 2,
+    ]);
+    expect(requests).toHaveLength(2);
+    expect(requests[0]).toMatchObject({
+      params: {
+        filter: {
+          from_block: { block_number: 1 },
+          to_block: { block_number: 2 },
+          chunk_size: 2,
+        },
+      },
+    });
+    expect(requests[1]).toMatchObject({
+      params: {
+        filter: {
+          continuation_token: "page-2",
+        },
+      },
+    });
+  });
+
+  it("resumes from a persisted cursor and skips replayed events", async () => {
+    const requests: unknown[] = [];
+    const resumeCursor = cursor(5, "0x2", 1);
+
+    mockRpcFetch((request) => {
+      requests.push(request);
+      return {
+        events: [
+          rawEvent({ blockNumber: 5, transactionHash: "0x1", eventIndex: 0 }),
+          rawEvent({ blockNumber: 5, transactionHash: "0x2", eventIndex: 1 }),
+          rawEvent({ blockNumber: 5, transactionHash: "0x3", eventIndex: 0 }),
+        ],
+      };
+    });
+
+    const messages = await collect(
+      backfillEvents({
+        url: RPC_URL,
+        fromBlock: { block_number: 0 },
+        continuationToken: "old-token",
+        cursor: resumeCursor,
+      }),
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].cursor).toMatchObject({
+      blockNumber: 5,
+      transactionHash: normalizeFelt("0x3"),
+      eventIndex: 0,
+    });
+    expect(requests[0]).toMatchObject({
+      params: {
+        filter: {
+          from_block: { block_number: 5 },
+        },
+      },
+    });
+    expect(
+      (requests[0] as JsonRpcRequest).params.filter.continuation_token,
+    ).toBeUndefined();
+  });
+});
+
+describe("WebSocket subscriptions", () => {
+  it("emits Pathfinder reorg notifications", async () => {
+    const sockets: MockWebSocket[] = [];
+    const iterator = connectSubscribeEvents({
+      url: WS_URL,
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+
+    const next = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+    await waitForSent(socket, "starknet_subscribeEvents");
+    socket.message({ jsonrpc: "2.0", id: 1, result: "sub-1" });
+    socket.message({
+      jsonrpc: "2.0",
+      method: "starknet_subscriptionReorg",
+      params: {
+        subscription_id: "sub-1",
+        result: {
+          starting_block_number: 12,
+          starting_block_hash: "0xabc",
+          ending_block_number: 13,
+          ending_block_hash: "0xdef",
+        },
+      },
+    });
+
+    await expect(next).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "reorg",
+        reorg: {
+          startingBlockNumber: 12,
+          startingBlockHash: normalizeFelt("0xabc"),
+          endingBlockNumber: 13,
+          endingBlockHash: normalizeFelt("0xdef"),
+        },
+      },
+    });
+
+    await iterator.return?.(undefined);
+  });
+
+  it("dedupes replayed events after reconnect", async () => {
+    const sockets: MockWebSocket[] = [];
+    const subscription = subscribeEvents({
+      url: WS_URL,
+      blockId: { block_number: 1 },
+      reconnect: { minDelayMs: 0, maxDelayMs: 0 },
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+    const iterator = subscription[Symbol.asyncIterator]();
+
+    const first = iterator.next();
+    const socket1 = await waitForSocket(sockets, 0);
+    socket1.open();
+    await waitForSent(socket1, "starknet_subscribeEvents");
+    socket1.message({ jsonrpc: "2.0", id: 1, result: "sub-1" });
+    socket1.message(eventNotification("sub-1", rawEvent({ blockNumber: 1 })));
+
+    await expect(first).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 1,
+        },
+      },
+    });
+
+    const second = iterator.next();
+    socket1.close();
+    const socket2 = await waitForSocket(sockets, 1);
+    socket2.open();
+    await waitForSent(socket2, "starknet_subscribeEvents");
+    socket2.message({ jsonrpc: "2.0", id: 1, result: "sub-2" });
+    socket2.message(eventNotification("sub-2", rawEvent({ blockNumber: 1 })));
+    socket2.message(
+      eventNotification(
+        "sub-2",
+        rawEvent({ blockNumber: 2, transactionHash: "0x2" }),
+      ),
+    );
+
+    await expect(second).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 2,
+        },
+      },
+    });
+
+    await subscription.unsubscribe();
+  });
+
+  it("surfaces TooManyBlocksBack without trying historical WS backfill", async () => {
+    const sockets: MockWebSocket[] = [];
+    const iterator = connectSubscribeEvents({
+      url: WS_URL,
+      blockId: { block_number: 1 },
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+
+    const next = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+    await waitForSent(socket, "starknet_subscribeEvents");
+    socket.message({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: 68,
+        message: "Cannot go back more than 1024 blocks",
+        data: { limit: 1024, requested: 1025 },
+      },
+    });
+
+    await expect(next).rejects.toBeInstanceOf(TooManyBlocksBackError);
+    expect(socket.sent).toHaveLength(1);
+  });
+});
+
+describe("combined stream", () => {
+  it("dedupes the inclusive HTTP-to-WS handoff", async () => {
+    const sockets: MockWebSocket[] = [];
+    mockRpcFetch((request) => {
+      if (request.method === "starknet_getBlockWithTxHashes") {
+        return {
+          block_hash: "0x123",
+          block_number: 10,
+          timestamp: 100,
+          transactions: [],
+        };
+      }
+
+      if (request.method === "starknet_getEvents") {
+        return {
+          events: [rawEvent({ blockNumber: 10, transactionHash: "0x1" })],
+        };
+      }
+
+      throw new Error(`unexpected method ${request.method}`);
+    });
+
+    const iterator = streamEvents({
+      url: RPC_URL,
+      wsUrl: WS_URL,
+      fromBlock: { block_number: 0 },
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 10,
+        },
+      },
+    });
+
+    const live = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+    const subscribe = await waitForSent(socket, "starknet_subscribeEvents");
+    expect((subscribe.params as { block_id: unknown }).block_id).toEqual({
+      block_number: 10,
+    });
+    socket.message({ jsonrpc: "2.0", id: 1, result: "sub-1" });
+    socket.message(
+      eventNotification(
+        "sub-1",
+        rawEvent({ blockNumber: 10, transactionHash: "0x1" }),
+      ),
+    );
+    socket.message(
+      eventNotification(
+        "sub-1",
+        rawEvent({ blockNumber: 11, transactionHash: "0x2" }),
+      ),
+    );
+
+    await expect(live).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 11,
+        },
+      },
+    });
+
+    await iterator.return?.(undefined);
+  });
+});
+
+type JsonRpcRequest = {
+  method: string;
+  params: {
+    filter: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+};
+
+function cursor(
+  blockNumber: number,
+  transactionHash = "0x1",
+  eventIndex = 0,
+): EventCursor {
+  return { blockNumber, transactionHash, eventIndex };
+}
+
+function rawEvent({
+  blockNumber = 1,
+  blockHash = "0xabc",
+  transactionHash = "0x1",
+  transactionIndex = 0,
+  eventIndex = 0,
+  fromAddress = "0xaaa",
+  keys = ["0x111"],
+  data = ["0x222"],
+}: {
+  blockNumber?: number;
+  blockHash?: string;
+  transactionHash?: string;
+  transactionIndex?: number;
+  eventIndex?: number;
+  fromAddress?: string;
+  keys?: string[];
+  data?: string[];
+} = {}): RpcEvent {
+  return {
+    block_number: blockNumber,
+    block_hash: blockHash,
+    transaction_hash: transactionHash,
+    transaction_index: transactionIndex,
+    event_index: eventIndex,
+    from_address: fromAddress,
+    keys,
+    data,
+    finality_status: "ACCEPTED_ON_L2",
+  };
+}
+
+function eventNotification(subscriptionId: string, event: RpcEvent) {
+  return {
+    jsonrpc: "2.0",
+    method: "starknet_subscriptionEvents",
+    params: {
+      subscription_id: subscriptionId,
+      result: event,
+    },
+  };
+}
+
+function mockRpcFetch(handler: (request: JsonRpcRequest) => unknown): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as JsonRpcRequest & {
+        id?: number | string;
+      };
+      const result = handler(request);
+
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: request.id ?? 1,
+          result,
+        }),
+        {
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    }),
+  );
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const value of iterable) {
+    values.push(value);
+  }
+  return values;
+}
+
+function mockWebSocketFactory(sockets: MockWebSocket[]) {
+  return (url: string) => {
+    const socket = new MockWebSocket(url);
+    sockets.push(socket);
+    return socket;
+  };
+}
+
+class MockWebSocket {
+  readyState = 0;
+  sent: Array<Record<string, unknown>> = [];
+  readonly #listeners = new Map<string, Set<(event: unknown) => void>>();
+
+  constructor(readonly url: string) {}
+
+  send(data: string): void {
+    this.sent.push(JSON.parse(data) as Record<string, unknown>);
+  }
+
+  close(): void {
+    if (this.readyState === 3) {
+      return;
+    }
+
+    this.readyState = 3;
+    this.dispatch("close", {});
+  }
+
+  addEventListener(
+    type: "open" | "message" | "error" | "close",
+    listener: (event: unknown) => void,
+  ): void {
+    const listeners = this.#listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.#listeners.set(type, listeners);
+  }
+
+  removeEventListener(
+    type: "open" | "message" | "error" | "close",
+    listener: (event: unknown) => void,
+  ): void {
+    this.#listeners.get(type)?.delete(listener);
+  }
+
+  open(): void {
+    this.readyState = 1;
+    this.dispatch("open", {});
+  }
+
+  message(value: unknown): void {
+    this.dispatch("message", { data: JSON.stringify(value) });
+  }
+
+  private dispatch(type: string, event: unknown): void {
+    for (const listener of this.#listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+async function waitForSocket(
+  sockets: MockWebSocket[],
+  index: number,
+): Promise<MockWebSocket> {
+  await waitFor(() => sockets[index] !== undefined);
+  return sockets[index];
+}
+
+async function waitForSent(
+  socket: MockWebSocket,
+  method: string,
+): Promise<Record<string, unknown>> {
+  await waitFor(() => socket.sent.some((message) => message.method === method));
+  const message = socket.sent.find((message) => message.method === method);
+  if (!message) {
+    throw new Error(`missing sent message ${method}`);
+  }
+
+  return message;
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const startedAt = Date.now();
+
+  while (!predicate()) {
+    if (Date.now() - startedAt > 1_000) {
+      throw new Error("timed out waiting for condition");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}

--- a/packages/starknet-rpc/src/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/src/starknet-rpc.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { backfillEvents } from "./backfill";
+import { getBlockWithTxHashes } from "./block-cache";
 import { compareEventCursor } from "./cursor";
+import { getEvents } from "./http";
 import { normalizeFelt } from "./normalize";
 import { streamEvents } from "./stream";
 import { subscribeEvents } from "./subscribe";
@@ -46,7 +48,7 @@ describe("HTTP backfill", () => {
         throw new Error(`unexpected method ${request.method}`);
       }
 
-      if (!request.params.filter.continuation_token) {
+      if (!singleParam(request).continuation_token) {
         return {
           events: [
             rawEvent({ blockNumber: 1, transactionHash: "0x1", eventIndex: 0 }),
@@ -76,22 +78,80 @@ describe("HTTP backfill", () => {
       1, 1, 2,
     ]);
     expect(requests).toHaveLength(2);
+    expect((requests[0] as JsonRpcRequest).params).toEqual([
+      {
+        from_block: { block_number: 1 },
+        to_block: { block_number: 2 },
+        chunk_size: 2,
+      },
+    ]);
+    expect((requests[1] as JsonRpcRequest).params).toEqual([
+      {
+        from_block: { block_number: 1 },
+        to_block: { block_number: 2 },
+        chunk_size: 2,
+        continuation_token: "page-2",
+      },
+    ]);
+  });
+
+  it("sends getEvents filters as positional JSON-RPC params", async () => {
+    const requests: unknown[] = [];
+    mockRpcFetch((request) => {
+      requests.push(request);
+      return { events: [] };
+    });
+
+    await getEvents({
+      url: RPC_URL,
+      fromBlock: { block_number: 1 },
+      toBlock: { block_number: 2 },
+      addresses: ["0xaaa"],
+      keys: [["0x111"]],
+      chunkSize: 25,
+      continuationToken: "page-2",
+    });
+
+    expect(requests).toHaveLength(1);
     expect(requests[0]).toMatchObject({
-      params: {
-        filter: {
-          from_block: { block_number: 1 },
-          to_block: { block_number: 2 },
-          chunk_size: 2,
-        },
-      },
+      method: "starknet_getEvents",
     });
-    expect(requests[1]).toMatchObject({
-      params: {
-        filter: {
-          continuation_token: "page-2",
-        },
+    expect((requests[0] as JsonRpcRequest).params).toEqual([
+      {
+        from_block: { block_number: 1 },
+        to_block: { block_number: 2 },
+        address: normalizeFelt("0xaaa"),
+        keys: [[normalizeFelt("0x111")]],
+        chunk_size: 25,
+        continuation_token: "page-2",
       },
+    ]);
+  });
+
+  it("sends getBlockWithTxHashes block ids as positional JSON-RPC params", async () => {
+    const requests: unknown[] = [];
+    mockRpcFetch((request) => {
+      requests.push(request);
+      return {
+        block_hash: "0x123",
+        block_number: 10,
+        timestamp: 100,
+        transactions: [],
+      };
     });
+
+    await getBlockWithTxHashes({
+      url: RPC_URL,
+      blockId: { block_number: 10 },
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      method: "starknet_getBlockWithTxHashes",
+    });
+    expect((requests[0] as JsonRpcRequest).params).toEqual([
+      { block_number: 10 },
+    ]);
   });
 
   it("resumes from a persisted cursor and skips replayed events", async () => {
@@ -124,15 +184,14 @@ describe("HTTP backfill", () => {
       transactionHash: normalizeFelt("0x3"),
       eventIndex: 0,
     });
-    expect(requests[0]).toMatchObject({
-      params: {
-        filter: {
-          from_block: { block_number: 5 },
-        },
+    expect((requests[0] as JsonRpcRequest).params).toEqual([
+      {
+        from_block: { block_number: 5 },
+        chunk_size: 100,
       },
-    });
+    ]);
     expect(
-      (requests[0] as JsonRpcRequest).params.filter.continuation_token,
+      singleParam(requests[0] as JsonRpcRequest).continuation_token,
     ).toBeUndefined();
   });
 });
@@ -337,11 +396,22 @@ describe("combined stream", () => {
 
 type JsonRpcRequest = {
   method: string;
-  params: {
-    filter: Record<string, unknown>;
-    [key: string]: unknown;
-  };
+  params: unknown;
 };
+
+function singleParam(request: JsonRpcRequest): Record<string, unknown> {
+  const params = request.params;
+  if (!Array.isArray(params) || params.length !== 1) {
+    throw new Error("expected one positional JSON-RPC param");
+  }
+
+  const [param] = params;
+  if (typeof param !== "object" || param === null || Array.isArray(param)) {
+    throw new Error("expected positional JSON-RPC param object");
+  }
+
+  return param as Record<string, unknown>;
+}
 
 function cursor(
   blockNumber: number,

--- a/packages/starknet-rpc/src/stream-config.ts
+++ b/packages/starknet-rpc/src/stream-config.ts
@@ -1,0 +1,387 @@
+import type { Bytes } from "@apibara/protocol";
+import {
+  type BlockInfo,
+  type FetchBlockByHashArgs,
+  type FetchBlockByHashResult,
+  type FetchBlockRangeArgs,
+  type FetchBlockRangeResult,
+  type FetchCursorArgs,
+  type FetchCursorRangeArgs,
+  RpcStreamConfig,
+  type ValidateFilterResult,
+} from "@apibara/protocol/rpc";
+import { backfillEvents } from "./backfill";
+import {
+  type StarknetBlockWithTxHashes,
+  getBlockWithTxHashes,
+} from "./block-cache";
+import { normalizeFelt } from "./normalize";
+import type { Felt, NormalizedEvent } from "./types";
+
+export interface StarknetRpcStreamFilter {
+  addresses?: Felt[];
+  keys?: Felt[][];
+  chunkSize?: number;
+  header?: "always" | "on_data";
+}
+
+export interface StarknetRpcBlockHeader {
+  blockNumber: number;
+  blockHash: Felt;
+  parentBlockHash: Felt;
+  timestamp: number;
+  raw: StarknetBlockWithTxHashes;
+}
+
+export interface StarknetRpcBlock {
+  header: StarknetRpcBlockHeader;
+  events: NormalizedEvent[];
+}
+
+export interface StarknetRpcStreamOptions {
+  url: string;
+  /** How many blocks to scan in a single starknet_getEvents range when clamping is allowed. */
+  getEventsRangeSize?: bigint;
+  chunkSize?: number;
+  headRefreshIntervalMs?: number;
+  finalizedRefreshIntervalMs?: number;
+  signal?: AbortSignal;
+}
+
+export class StarknetRpcStream extends RpcStreamConfig<
+  StarknetRpcStreamFilter,
+  StarknetRpcBlock
+> {
+  private readonly getEventsRangeSize: bigint;
+
+  constructor(private readonly options: StarknetRpcStreamOptions) {
+    super();
+
+    this.getEventsRangeSize = normalizeGetEventsRangeSize(
+      options.getEventsRangeSize,
+    );
+  }
+
+  headRefreshIntervalMs(): number {
+    return this.options.headRefreshIntervalMs ?? 1_000;
+  }
+
+  finalizedRefreshIntervalMs(): number {
+    return this.options.finalizedRefreshIntervalMs ?? 30_000;
+  }
+
+  validateFilter(filter: StarknetRpcStreamFilter): ValidateFilterResult {
+    if (
+      filter.header &&
+      filter.header !== "always" &&
+      filter.header !== "on_data"
+    ) {
+      return {
+        valid: false,
+        error: 'header must be "always" or "on_data"',
+      };
+    }
+
+    if (
+      filter.chunkSize !== undefined &&
+      !isPositiveInteger(filter.chunkSize)
+    ) {
+      return {
+        valid: false,
+        error: "chunkSize must be a positive integer",
+      };
+    }
+
+    if (filter.addresses?.some((address) => !isHexString(address))) {
+      return {
+        valid: false,
+        error: "addresses must be 0x-prefixed hex strings",
+      };
+    }
+
+    if (filter.keys?.some((keys) => keys.some((key) => !isHexString(key)))) {
+      return {
+        valid: false,
+        error: "keys must be 0x-prefixed hex strings",
+      };
+    }
+
+    return { valid: true };
+  }
+
+  async fetchCursor(args: FetchCursorArgs): Promise<BlockInfo | null> {
+    const block = await getBlockWithTxHashes({
+      url: this.options.url,
+      blockId: blockIdFromCursorArgs(args),
+      signal: this.options.signal,
+    });
+
+    return blockInfoFromRpcBlock(block);
+  }
+
+  async fetchCursorRange({
+    startBlockNumber,
+    endBlockNumber,
+  }: FetchCursorRangeArgs): Promise<BlockInfo[]> {
+    const count = Number(endBlockNumber - startBlockNumber) + 1;
+    return Promise.all(
+      Array.from({ length: count }, async (_, index) => {
+        const blockNumber = startBlockNumber + BigInt(index);
+        const info = await this.fetchCursor({ blockNumber });
+        if (!info) {
+          throw new Error(`Block ${blockNumber} not found`);
+        }
+        return info;
+      }),
+    );
+  }
+
+  async fetchBlockRange({
+    startBlock,
+    maxBlock,
+    force,
+    clampAllowed,
+    filter,
+  }: FetchBlockRangeArgs<StarknetRpcStreamFilter>): Promise<
+    FetchBlockRangeResult<StarknetRpcBlock>
+  > {
+    const endBlock = clampAllowed
+      ? clampBlockRange(startBlock, maxBlock, this.getEventsRangeSize)
+      : maxBlock;
+    const startBlockNumber = bigintToSafeBlockNumber(startBlock);
+    const endBlockNumber = bigintToSafeBlockNumber(endBlock);
+    const eventsByBlock = new Map<number, NormalizedEvent[]>();
+
+    for await (const message of backfillEvents({
+      url: this.options.url,
+      fromBlock: { block_number: startBlockNumber },
+      toBlock: { block_number: endBlockNumber },
+      addresses: filter.addresses,
+      keys: filter.keys,
+      chunkSize: filter.chunkSize ?? this.options.chunkSize,
+      signal: this.options.signal,
+    })) {
+      const events = eventsByBlock.get(message.event.blockNumber) ?? [];
+      events.push(message.event);
+      eventsByBlock.set(message.event.blockNumber, events);
+    }
+
+    const blockNumbers = blockNumbersForResult({
+      startBlockNumber,
+      endBlockNumber,
+      force,
+      header: filter.header,
+      eventBlockNumbers: eventsByBlock.keys(),
+    });
+
+    const data = await Promise.all(
+      blockNumbers.map(async (blockNumber) => {
+        const block = await this.fetchRpcBlock({ block_number: blockNumber });
+        const header = blockHeaderFromRpcBlock(block);
+        const events = eventsByBlock.get(blockNumber) ?? [];
+        events.sort((a, b) => {
+          if (a.transactionIndex !== b.transactionIndex) {
+            return a.transactionIndex - b.transactionIndex;
+          }
+          return a.eventIndex - b.eventIndex;
+        });
+
+        return {
+          cursor: undefined,
+          endCursor: cursorFromHeader(header),
+          block: { header, events },
+        };
+      }),
+    );
+
+    return {
+      startBlock,
+      endBlock,
+      data,
+    };
+  }
+
+  async fetchHeaderByHash({
+    blockHash,
+  }: FetchBlockByHashArgs<StarknetRpcStreamFilter>): Promise<
+    FetchBlockByHashResult<StarknetRpcBlock>
+  > {
+    const block = await this.fetchRpcBlock({ block_hash: blockHash });
+    const header = blockHeaderFromRpcBlock(block);
+    const blockInfo = blockInfoFromHeader(header);
+
+    return {
+      blockInfo,
+      data: {
+        cursor:
+          header.blockNumber > 0
+            ? {
+                orderKey: BigInt(header.blockNumber - 1),
+                uniqueKey: header.parentBlockHash as Bytes,
+              }
+            : undefined,
+        endCursor: cursorFromHeader(header),
+        block: {
+          header,
+          events: [],
+        },
+      },
+    };
+  }
+
+  private fetchRpcBlock(
+    blockId: { block_number: number } | { block_hash: Felt },
+  ) {
+    return getBlockWithTxHashes({
+      url: this.options.url,
+      blockId,
+      signal: this.options.signal,
+    });
+  }
+}
+
+function blockIdFromCursorArgs(args: FetchCursorArgs) {
+  if (args.blockNumber !== undefined) {
+    return { block_number: bigintToSafeBlockNumber(args.blockNumber) };
+  }
+
+  if (args.blockHash !== undefined) {
+    return { block_hash: args.blockHash };
+  }
+
+  return args.blockTag === "finalized" ? "l1_accepted" : "latest";
+}
+
+function clampBlockRange(
+  startBlock: bigint,
+  maxBlock: bigint,
+  rangeSize: bigint,
+): bigint {
+  return minBigInt(maxBlock, startBlock + rangeSize - 1n);
+}
+
+function minBigInt(a: bigint, b: bigint): bigint {
+  return a < b ? a : b;
+}
+
+function normalizeGetEventsRangeSize(value?: bigint): bigint {
+  if (value === undefined) {
+    return 1_000n;
+  }
+
+  if (value <= 0n) {
+    throw new Error("getEventsRangeSize must be positive");
+  }
+
+  return value;
+}
+
+function blockNumbersForResult({
+  startBlockNumber,
+  endBlockNumber,
+  force,
+  header,
+  eventBlockNumbers,
+}: {
+  startBlockNumber: number;
+  endBlockNumber: number;
+  force: boolean;
+  header?: StarknetRpcStreamFilter["header"];
+  eventBlockNumbers: Iterable<number>;
+}): number[] {
+  if (header === "always") {
+    return Array.from(
+      { length: endBlockNumber - startBlockNumber + 1 },
+      (_, index) => startBlockNumber + index,
+    );
+  }
+
+  const blockNumbers = Array.from(new Set(eventBlockNumbers)).sort(
+    (a, b) => a - b,
+  );
+
+  if (blockNumbers.length === 0 && force) {
+    return [endBlockNumber];
+  }
+
+  return blockNumbers;
+}
+
+function blockInfoFromRpcBlock(block: StarknetBlockWithTxHashes): BlockInfo {
+  return blockInfoFromHeader(blockHeaderFromRpcBlock(block));
+}
+
+function blockInfoFromHeader(header: StarknetRpcBlockHeader): BlockInfo {
+  return {
+    blockNumber: BigInt(header.blockNumber),
+    blockHash: header.blockHash as Bytes,
+    parentBlockHash: header.parentBlockHash as Bytes,
+  };
+}
+
+function cursorFromHeader(header: StarknetRpcBlockHeader) {
+  return {
+    orderKey: BigInt(header.blockNumber),
+    uniqueKey: header.blockHash as Bytes,
+  };
+}
+
+function blockHeaderFromRpcBlock(
+  block: StarknetBlockWithTxHashes,
+): StarknetRpcBlockHeader {
+  if (
+    typeof block.block_number !== "number" ||
+    !Number.isInteger(block.block_number) ||
+    block.block_number < 0
+  ) {
+    throw new Error(
+      "starknet_getBlockWithTxHashes response is missing block_number",
+    );
+  }
+
+  if (typeof block.block_hash !== "string") {
+    throw new Error(
+      "starknet_getBlockWithTxHashes response is missing block_hash",
+    );
+  }
+
+  if (typeof block.parent_hash !== "string") {
+    throw new Error(
+      "starknet_getBlockWithTxHashes response is missing parent_hash",
+    );
+  }
+
+  if (
+    typeof block.timestamp !== "number" ||
+    !Number.isInteger(block.timestamp) ||
+    block.timestamp < 0
+  ) {
+    throw new Error(
+      "starknet_getBlockWithTxHashes response is missing timestamp",
+    );
+  }
+
+  return {
+    blockNumber: block.block_number,
+    blockHash: normalizeFelt(block.block_hash, "block.block_hash"),
+    parentBlockHash: normalizeFelt(block.parent_hash, "block.parent_hash"),
+    timestamp: block.timestamp,
+    raw: block,
+  };
+}
+
+function bigintToSafeBlockNumber(value: bigint): number {
+  if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`Block number ${value} is outside the safe integer range`);
+  }
+
+  return Number(value);
+}
+
+function isPositiveInteger(value: number): boolean {
+  return Number.isInteger(value) && value > 0;
+}
+
+function isHexString(value: string): boolean {
+  return typeof value === "string" && /^0x[0-9a-fA-F]+$/.test(value);
+}

--- a/packages/starknet-rpc/src/stream.ts
+++ b/packages/starknet-rpc/src/stream.ts
@@ -1,6 +1,10 @@
 import { backfillEvents } from "./backfill";
 import { StarknetBlockCache } from "./block-cache";
-import { compareEventCursor } from "./cursor";
+import {
+  compareEventCursor,
+  cursorBeforeBlock,
+  isCursorBeforeBlock,
+} from "./cursor";
 import { StarknetTransportError } from "./http";
 import { subscribeEvents } from "./subscribe";
 import type {
@@ -15,6 +19,7 @@ import { TooManyBlocksBackError } from "./ws";
 
 const DEFAULT_HTTP_RETRY_DELAY_MS = 500;
 const MAX_HTTP_RETRY_DELAY_MS = 10_000;
+const ZERO_FELT = `0x${"0".repeat(64)}`;
 
 export async function* streamEvents(
   options: StreamEventsOptions,
@@ -27,7 +32,9 @@ export async function* streamEvents(
   });
 
   let lastYieldedCursor = options.cursor;
-  let lastRealCursor = options.cursor;
+  let lastRealCursor = isRollbackCursor(options.cursor)
+    ? undefined
+    : options.cursor;
   let backfillFromBlock = options.fromBlock;
   let backfillCursor = options.cursor;
   let lastBackfilledBlockNumber = options.cursor?.blockNumber;
@@ -43,31 +50,54 @@ export async function* streamEvents(
       try {
         const head = await blockCache.getLatestBlock();
         headBlockId = { block_number: head.blockNumber };
+        const cursorForBackfill = backfillCursor;
+        const cursorPastAcceptedHead =
+          cursorForBackfill !== undefined &&
+          cursorForBackfill.blockNumber > head.blockNumber;
 
-        for await (const message of backfillEvents({
-          url: options.url,
-          fromBlock: backfillFromBlock,
-          toBlock: headBlockId,
-          addresses: options.addresses,
-          keys: options.keys,
-          chunkSize: options.chunkSize,
-          cursor: backfillCursor,
-          signal: options.signal,
-        })) {
-          if (message.type === "event") {
-            if (!shouldYieldEvent(message.cursor, lastYieldedCursor)) {
-              continue;
+        if (cursorPastAcceptedHead) {
+          const startingBlockNumber = head.blockNumber + 1;
+          const endingBlockNumber = cursorForBackfill.blockNumber;
+          const shouldEmitRollback =
+            !isRollbackCursor(cursorForBackfill) ||
+            cursorForBackfill.blockNumber > startingBlockNumber;
+
+          lastYieldedCursor = cursorBeforeBlock(startingBlockNumber);
+          lastRealCursor = undefined;
+          backfillCursor = undefined;
+          lastBackfilledBlockNumber = head.blockNumber;
+          blockCache.invalidateFrom(startingBlockNumber);
+          httpRetryAttempt = 0;
+
+          if (shouldEmitRollback) {
+            yield syntheticReorgMessage(startingBlockNumber, endingBlockNumber);
+          }
+        } else {
+          for await (const message of backfillEvents({
+            url: options.url,
+            fromBlock: backfillFromBlock,
+            toBlock: headBlockId,
+            addresses: options.addresses,
+            keys: options.keys,
+            chunkSize: options.chunkSize,
+            cursor: backfillCursor,
+            signal: options.signal,
+          })) {
+            if (message.type === "event") {
+              if (!shouldYieldEvent(message.cursor, lastYieldedCursor)) {
+                continue;
+              }
+
+              lastYieldedCursor = message.cursor;
+              lastRealCursor = message.cursor;
             }
 
-            lastYieldedCursor = message.cursor;
-            lastRealCursor = message.cursor;
+            yield message;
           }
 
-          yield message;
+          lastBackfilledBlockNumber = head.blockNumber;
+          httpRetryAttempt = 0;
         }
-
-        lastBackfilledBlockNumber = head.blockNumber;
-        httpRetryAttempt = 0;
       } catch (error) {
         if (!isRetryableHttpError(error, options.signal)) {
           throw error;
@@ -142,14 +172,20 @@ export async function* streamEvents(
       }
 
       const startingBlockNumber = reorg.reorg.startingBlockNumber;
+      const rollbackCursor =
+        reorg.rollbackCursor ?? cursorBeforeBlock(startingBlockNumber);
+      const rollbackMessage: ReorgMessage = {
+        ...reorg,
+        rollbackCursor,
+      };
       blockCache.invalidateFrom(startingBlockNumber);
-      lastYieldedCursor = cursorBeforeBlock(startingBlockNumber);
+      lastYieldedCursor = rollbackCursor;
       lastRealCursor = undefined;
       lastBackfilledBlockNumber = undefined;
       backfillFromBlock = { block_number: startingBlockNumber };
       backfillCursor = undefined;
 
-      yield reorg;
+      yield rollbackMessage;
     }
   } finally {
     if (subscription) {
@@ -193,20 +229,39 @@ function shouldYieldEvent(
   );
 }
 
-function cursorBeforeBlock(blockNumber: number): EventCursor {
-  // Synthetic in-memory cursor used only for local dedupe after a rollback.
-  return {
-    blockNumber,
-    transactionIndex: -1,
-    transactionHash: "0x0",
-    eventIndex: -1,
-  };
-}
-
 function throwIfAborted(signal: AbortSignal | undefined): void {
   if (signal?.aborted) {
     throw signal.reason ?? new Error("The operation was aborted.");
   }
+}
+
+function isRollbackCursor(cursor: EventCursor | undefined): boolean {
+  return cursor !== undefined && isCursorBeforeBlock(cursor);
+}
+
+function syntheticReorgMessage(
+  startingBlockNumber: number,
+  endingBlockNumber: number,
+): ReorgMessage {
+  const raw = {
+    starting_block_number: startingBlockNumber,
+    starting_block_hash: "0x0",
+    ending_block_number: endingBlockNumber,
+    ending_block_hash: "0x0",
+  };
+
+  return {
+    type: "reorg",
+    reorg: {
+      startingBlockNumber,
+      startingBlockHash: ZERO_FELT,
+      endingBlockNumber,
+      endingBlockHash: ZERO_FELT,
+      synthetic: true,
+      raw,
+    },
+    rollbackCursor: cursorBeforeBlock(startingBlockNumber),
+  };
 }
 
 function rejectUnsupportedOptions(options: StreamEventsOptions): void {

--- a/packages/starknet-rpc/src/stream.ts
+++ b/packages/starknet-rpc/src/stream.ts
@@ -97,6 +97,10 @@ export async function* streamEvents(
           initialCursorRollbackPending = false;
         }
 
+        if (!skipBackfill && isBlockNumberId(backfillFromBlock)) {
+          skipBackfill = backfillFromBlock.block_number > head.blockNumber;
+        }
+
         if (!skipBackfill) {
           for await (const message of backfillEvents({
             url: options.url,
@@ -126,6 +130,8 @@ export async function* streamEvents(
 
           lastBackfilledBlockNumber = head.blockNumber;
           httpRetryAttempt = 0;
+        } else {
+          lastBackfilledBlockNumber = head.blockNumber;
         }
       } catch (error) {
         if (!isRetryableHttpError(error, options.signal)) {
@@ -157,6 +163,8 @@ export async function* streamEvents(
         finalityStatus: options.finalityStatus,
         cursor: lastRealCursor,
         signal: options.signal,
+        idleTimeoutMs: options.idleTimeoutMs,
+        maxQueueSize: options.maxQueueSize,
         webSocketFactory: options.webSocketFactory,
       });
 
@@ -297,6 +305,14 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
 
 function isRollbackCursor(cursor: EventCursor | undefined): boolean {
   return cursor !== undefined && isCursorBeforeBlock(cursor);
+}
+
+function isBlockNumberId(
+  blockId: BlockId | undefined,
+): blockId is { block_number: number } {
+  return (
+    typeof blockId === "object" && blockId !== null && "block_number" in blockId
+  );
 }
 
 function shouldReplayInitialCursorBlock(options: StreamEventsOptions): boolean {

--- a/packages/starknet-rpc/src/stream.ts
+++ b/packages/starknet-rpc/src/stream.ts
@@ -1,6 +1,7 @@
 import { backfillEvents } from "./backfill";
-import { getLatestBlock } from "./block-cache";
+import { StarknetBlockCache } from "./block-cache";
 import { compareEventCursor } from "./cursor";
+import { StarknetTransportError } from "./http";
 import { subscribeEvents } from "./subscribe";
 import type {
   BlockId,
@@ -10,52 +11,84 @@ import type {
   StreamEventsOptions,
   StreamMessage,
 } from "./types";
+import { TooManyBlocksBackError } from "./ws";
+
+const DEFAULT_HTTP_RETRY_DELAY_MS = 500;
+const MAX_HTTP_RETRY_DELAY_MS = 10_000;
 
 export async function* streamEvents(
   options: StreamEventsOptions,
 ): AsyncGenerator<StreamMessage> {
+  rejectUnsupportedOptions(options);
+
+  const blockCache = new StarknetBlockCache({
+    url: options.url,
+    signal: options.signal,
+  });
+
   let lastYieldedCursor = options.cursor;
   let lastRealCursor = options.cursor;
   let backfillFromBlock = options.fromBlock;
   let backfillCursor = options.cursor;
+  let lastBackfilledBlockNumber = options.cursor?.blockNumber;
+  let httpRetryAttempt = 0;
   let subscription: EventSubscription | undefined;
 
   try {
     while (true) {
       throwIfAborted(options.signal);
 
-      const head = await getLatestBlock({
-        url: options.url,
-        signal: options.signal,
-      });
-      const headBlockId: BlockId = { block_number: head.blockNumber };
+      let headBlockId: BlockId;
 
-      for await (const message of backfillEvents({
-        url: options.url,
-        fromBlock: backfillFromBlock,
-        toBlock: headBlockId,
-        addresses: options.addresses,
-        keys: options.keys,
-        chunkSize: options.chunkSize,
-        cursor: backfillCursor,
-        signal: options.signal,
-      })) {
-        if (message.type === "event") {
-          if (!shouldYieldEvent(message.cursor, lastYieldedCursor)) {
-            continue;
+      try {
+        const head = await blockCache.getLatestBlock();
+        headBlockId = { block_number: head.blockNumber };
+
+        for await (const message of backfillEvents({
+          url: options.url,
+          fromBlock: backfillFromBlock,
+          toBlock: headBlockId,
+          addresses: options.addresses,
+          keys: options.keys,
+          chunkSize: options.chunkSize,
+          cursor: backfillCursor,
+          signal: options.signal,
+        })) {
+          if (message.type === "event") {
+            if (!shouldYieldEvent(message.cursor, lastYieldedCursor)) {
+              continue;
+            }
+
+            lastYieldedCursor = message.cursor;
+            lastRealCursor = message.cursor;
           }
 
-          lastYieldedCursor = message.cursor;
-          lastRealCursor = message.cursor;
+          yield message;
         }
 
-        yield message;
+        lastBackfilledBlockNumber = head.blockNumber;
+        httpRetryAttempt = 0;
+      } catch (error) {
+        if (!isRetryableHttpError(error, options.signal)) {
+          throw error;
+        }
+
+        if (lastRealCursor) {
+          backfillCursor = lastRealCursor;
+        }
+
+        httpRetryAttempt += 1;
+        await waitForStreamRetry(
+          retryDelayMs(httpRetryAttempt),
+          options.signal,
+        );
+        continue;
       }
 
       throwIfAborted(options.signal);
 
-      backfillFromBlock = undefined;
-      backfillCursor = lastRealCursor;
+      backfillFromBlock = headBlockId;
+      backfillCursor = undefined;
 
       subscription = subscribeEvents({
         url: options.wsUrl,
@@ -68,19 +101,51 @@ export async function* streamEvents(
         webSocketFactory: options.webSocketFactory,
       });
 
-      const reorg = yield* yieldFromSubscription(
-        subscription,
+      const subscriptionState = {
         lastYieldedCursor,
-      );
-      subscription = undefined;
+        lastRealCursor,
+      };
+      let reorg: ReorgMessage | undefined;
+
+      try {
+        reorg = yield* yieldFromSubscription(subscription, subscriptionState);
+        lastYieldedCursor = subscriptionState.lastYieldedCursor;
+        lastRealCursor = subscriptionState.lastRealCursor;
+        subscription = undefined;
+      } catch (error) {
+        lastYieldedCursor = subscriptionState.lastYieldedCursor;
+        lastRealCursor = subscriptionState.lastRealCursor;
+
+        if (!(error instanceof TooManyBlocksBackError)) {
+          throw error;
+        }
+
+        if (subscription) {
+          await subscription.unsubscribe();
+        }
+        subscription = undefined;
+
+        const resumeBlockNumber = Math.max(
+          lastBackfilledBlockNumber ?? 0,
+          lastRealCursor?.blockNumber ?? 0,
+        );
+        backfillFromBlock = { block_number: resumeBlockNumber };
+        backfillCursor =
+          lastRealCursor && lastRealCursor.blockNumber >= resumeBlockNumber
+            ? lastRealCursor
+            : undefined;
+        continue;
+      }
 
       if (!reorg) {
         return;
       }
 
       const startingBlockNumber = reorg.reorg.startingBlockNumber;
+      blockCache.invalidateFrom(startingBlockNumber);
       lastYieldedCursor = cursorBeforeBlock(startingBlockNumber);
       lastRealCursor = undefined;
+      lastBackfilledBlockNumber = undefined;
       backfillFromBlock = { block_number: startingBlockNumber };
       backfillCursor = undefined;
 
@@ -95,21 +160,23 @@ export async function* streamEvents(
 
 async function* yieldFromSubscription(
   subscription: EventSubscription,
-  initialCursor: EventCursor | undefined,
+  state: {
+    lastYieldedCursor: EventCursor | undefined;
+    lastRealCursor: EventCursor | undefined;
+  },
 ): AsyncGenerator<StreamMessage, ReorgMessage | undefined> {
-  let lastYieldedCursor = initialCursor;
-
   for await (const message of subscription) {
     if (message.type === "reorg") {
       await subscription.unsubscribe();
       return message;
     }
 
-    if (!shouldYieldEvent(message.cursor, lastYieldedCursor)) {
+    if (!shouldYieldEvent(message.cursor, state.lastYieldedCursor)) {
       continue;
     }
 
-    lastYieldedCursor = message.cursor;
+    state.lastYieldedCursor = message.cursor;
+    state.lastRealCursor = message.cursor;
     yield message;
   }
 
@@ -140,4 +207,52 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
   if (signal?.aborted) {
     throw signal.reason ?? new Error("The operation was aborted.");
   }
+}
+
+function rejectUnsupportedOptions(options: StreamEventsOptions): void {
+  if ((options as { toBlock?: unknown }).toBlock !== undefined) {
+    throw new Error(
+      "streamEvents does not support toBlock. Use backfillEvents for bounded historical indexing.",
+    );
+  }
+}
+
+function isRetryableHttpError(
+  error: unknown,
+  signal: AbortSignal | undefined,
+): boolean {
+  return !signal?.aborted && error instanceof StarknetTransportError;
+}
+
+function retryDelayMs(attempt: number): number {
+  const exponentialDelay =
+    DEFAULT_HTTP_RETRY_DELAY_MS * 2 ** Math.max(0, attempt - 1);
+  const boundedDelay = Math.min(exponentialDelay, MAX_HTTP_RETRY_DELAY_MS);
+  const jitter = Math.random() * boundedDelay * 0.2;
+
+  return Math.min(MAX_HTTP_RETRY_DELAY_MS, Math.round(boundedDelay + jitter));
+}
+
+async function waitForStreamRetry(
+  delayMs: number,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  if (signal?.aborted || delayMs <= 0) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener?.("abort", onAbort);
+      resolve();
+    };
+
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener?.("abort", onAbort);
+      resolve();
+    }, delayMs);
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }

--- a/packages/starknet-rpc/src/stream.ts
+++ b/packages/starknet-rpc/src/stream.ts
@@ -4,6 +4,8 @@ import { DEFAULT_SUBSCRIPTION_FINALITY_STATUS } from "./constants";
 import {
   compareEventCursor,
   cursorBeforeBlock,
+  eventCursorKey,
+  eventVersionKey,
   isCursorBeforeBlock,
 } from "./cursor";
 import { StarknetTransportError } from "./http";
@@ -42,6 +44,7 @@ export async function* streamEvents(
   let httpRetryAttempt = 0;
   let subscription: EventSubscription | undefined;
   let initialCursorRollbackPending = shouldReplayInitialCursorBlock(options);
+  const seenEvents = new RememberedEventVersions(2_048);
 
   try {
     while (true) {
@@ -112,6 +115,10 @@ export async function* streamEvents(
 
               lastYieldedCursor = message.cursor;
               lastRealCursor = message.cursor;
+              seenEvents.remember(
+                eventCursorKey(message.cursor),
+                eventVersionKey(message.event),
+              );
             }
 
             yield message;
@@ -156,6 +163,7 @@ export async function* streamEvents(
       const subscriptionState = {
         lastYieldedCursor,
         lastRealCursor,
+        seenEvents,
       };
       let reorg: ReorgMessage | undefined;
 
@@ -201,6 +209,7 @@ export async function* streamEvents(
         rollbackCursor,
       };
       blockCache.invalidateFrom(startingBlockNumber);
+      seenEvents.clear();
       lastYieldedCursor = rollbackCursor;
       lastRealCursor = undefined;
       lastBackfilledBlockNumber = undefined;
@@ -221,6 +230,7 @@ async function* yieldFromSubscription(
   state: {
     lastYieldedCursor: EventCursor | undefined;
     lastRealCursor: EventCursor | undefined;
+    seenEvents: RememberedEventVersions;
   },
 ): AsyncGenerator<StreamMessage, ReorgMessage | undefined> {
   for await (const message of subscription) {
@@ -229,12 +239,23 @@ async function* yieldFromSubscription(
       return message;
     }
 
-    if (!shouldYieldEvent(message.cursor, state.lastYieldedCursor)) {
+    const key = eventCursorKey(message.cursor);
+    const version = eventVersionKey(message.event);
+    if (
+      !shouldYieldEventVersion(
+        message.cursor,
+        key,
+        version,
+        state.lastYieldedCursor,
+        state.seenEvents,
+      )
+    ) {
       continue;
     }
 
     state.lastYieldedCursor = message.cursor;
     state.lastRealCursor = message.cursor;
+    state.seenEvents.remember(key, version);
     yield message;
   }
 
@@ -248,6 +269,23 @@ function shouldYieldEvent(
   return (
     lastYieldedCursor === undefined ||
     compareEventCursor(cursor, lastYieldedCursor) > 0
+  );
+}
+
+function shouldYieldEventVersion(
+  cursor: EventCursor,
+  key: string,
+  version: string,
+  lastYieldedCursor: EventCursor | undefined,
+  seenEvents: RememberedEventVersions,
+): boolean {
+  if (seenEvents.has(key, version)) {
+    return false;
+  }
+
+  return (
+    lastYieldedCursor === undefined ||
+    compareEventCursor(cursor, lastYieldedCursor) >= 0
   );
 }
 
@@ -304,6 +342,47 @@ function syntheticReorgMessage(
     },
     rollbackCursor: cursorBeforeBlock(startingBlockNumber),
   };
+}
+
+class RememberedEventVersions {
+  private readonly versions = new Map<string, Set<string>>();
+  private readonly order: string[] = [];
+
+  constructor(private readonly maxSize: number) {}
+
+  has(key: string, version: string): boolean {
+    return this.versions.get(key)?.has(version) ?? false;
+  }
+
+  remember(key: string, version: string): void {
+    const versions = this.versions.get(key) ?? new Set<string>();
+    if (versions.has(version)) {
+      return;
+    }
+
+    versions.add(version);
+    this.versions.set(key, versions);
+    this.order.push(`${key}\0${version}`);
+
+    while (this.order.length > this.maxSize) {
+      const oldest = this.order.shift();
+      if (!oldest) {
+        continue;
+      }
+
+      const [oldestKey, oldestVersion] = oldest.split("\0", 2);
+      const oldestVersions = this.versions.get(oldestKey);
+      oldestVersions?.delete(oldestVersion);
+      if (oldestVersions?.size === 0) {
+        this.versions.delete(oldestKey);
+      }
+    }
+  }
+
+  clear(): void {
+    this.versions.clear();
+    this.order.length = 0;
+  }
 }
 
 function rejectUnsupportedOptions(options: StreamEventsOptions): void {

--- a/packages/starknet-rpc/src/stream.ts
+++ b/packages/starknet-rpc/src/stream.ts
@@ -1,5 +1,6 @@
 import { backfillEvents } from "./backfill";
 import { StarknetBlockCache } from "./block-cache";
+import { DEFAULT_SUBSCRIPTION_FINALITY_STATUS } from "./constants";
 import {
   compareEventCursor,
   cursorBeforeBlock,
@@ -40,6 +41,7 @@ export async function* streamEvents(
   let lastBackfilledBlockNumber = options.cursor?.blockNumber;
   let httpRetryAttempt = 0;
   let subscription: EventSubscription | undefined;
+  let initialCursorRollbackPending = shouldReplayInitialCursorBlock(options);
 
   try {
     while (true) {
@@ -51,28 +53,48 @@ export async function* streamEvents(
         const head = await blockCache.getLatestBlock();
         headBlockId = { block_number: head.blockNumber };
         const cursorForBackfill = backfillCursor;
+        const initialRollbackCursor =
+          initialCursorRollbackPending && cursorForBackfill !== undefined
+            ? cursorForBackfill
+            : undefined;
         const cursorPastAcceptedHead =
-          cursorForBackfill !== undefined &&
-          cursorForBackfill.blockNumber > head.blockNumber;
+          initialRollbackCursor !== undefined
+            ? initialRollbackCursor.blockNumber > head.blockNumber
+            : cursorForBackfill !== undefined &&
+              cursorForBackfill.blockNumber > head.blockNumber;
+        const shouldRollbackCursorBlock =
+          initialRollbackCursor !== undefined || cursorPastAcceptedHead;
 
-        if (cursorPastAcceptedHead) {
-          const startingBlockNumber = head.blockNumber + 1;
+        let skipBackfill = false;
+
+        if (shouldRollbackCursorBlock && cursorForBackfill !== undefined) {
+          initialCursorRollbackPending = false;
+          const startingBlockNumber = cursorPastAcceptedHead
+            ? head.blockNumber + 1
+            : cursorForBackfill.blockNumber;
           const endingBlockNumber = cursorForBackfill.blockNumber;
+          const rollbackCursor = cursorBeforeBlock(startingBlockNumber);
           const shouldEmitRollback =
             !isRollbackCursor(cursorForBackfill) ||
             cursorForBackfill.blockNumber > startingBlockNumber;
 
-          lastYieldedCursor = cursorBeforeBlock(startingBlockNumber);
+          lastYieldedCursor = rollbackCursor;
           lastRealCursor = undefined;
+          backfillFromBlock = { block_number: startingBlockNumber };
           backfillCursor = undefined;
           lastBackfilledBlockNumber = head.blockNumber;
           blockCache.invalidateFrom(startingBlockNumber);
           httpRetryAttempt = 0;
+          skipBackfill = startingBlockNumber > head.blockNumber;
 
           if (shouldEmitRollback) {
             yield syntheticReorgMessage(startingBlockNumber, endingBlockNumber);
           }
         } else {
+          initialCursorRollbackPending = false;
+        }
+
+        if (!skipBackfill) {
           for await (const message of backfillEvents({
             url: options.url,
             fromBlock: backfillFromBlock,
@@ -237,6 +259,26 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
 
 function isRollbackCursor(cursor: EventCursor | undefined): boolean {
   return cursor !== undefined && isCursorBeforeBlock(cursor);
+}
+
+function shouldReplayInitialCursorBlock(options: StreamEventsOptions): boolean {
+  if (!options.cursor || isRollbackCursor(options.cursor)) {
+    return false;
+  }
+
+  const cursorFinalityStatus = options.cursorFinalityStatus;
+  if (
+    cursorFinalityStatus === "ACCEPTED_ON_L2" ||
+    cursorFinalityStatus === "ACCEPTED_ON_L1"
+  ) {
+    return false;
+  }
+
+  return (
+    cursorFinalityStatus === "PRE_CONFIRMED" ||
+    (options.finalityStatus ?? DEFAULT_SUBSCRIPTION_FINALITY_STATUS) ===
+      "PRE_CONFIRMED"
+  );
 }
 
 function syntheticReorgMessage(

--- a/packages/starknet-rpc/src/stream.ts
+++ b/packages/starknet-rpc/src/stream.ts
@@ -1,0 +1,142 @@
+import { backfillEvents } from "./backfill";
+import { getLatestBlock } from "./block-cache";
+import { compareEventCursor } from "./cursor";
+import { subscribeEvents } from "./subscribe";
+import type {
+  BlockId,
+  EventCursor,
+  EventSubscription,
+  ReorgMessage,
+  StreamEventsOptions,
+  StreamMessage,
+} from "./types";
+
+export async function* streamEvents(
+  options: StreamEventsOptions,
+): AsyncGenerator<StreamMessage> {
+  let lastYieldedCursor = options.cursor;
+  let lastRealCursor = options.cursor;
+  let backfillFromBlock = options.fromBlock;
+  let backfillCursor = options.cursor;
+  let subscription: EventSubscription | undefined;
+
+  try {
+    while (true) {
+      throwIfAborted(options.signal);
+
+      const head = await getLatestBlock({
+        url: options.url,
+        signal: options.signal,
+      });
+      const headBlockId: BlockId = { block_number: head.blockNumber };
+
+      for await (const message of backfillEvents({
+        url: options.url,
+        fromBlock: backfillFromBlock,
+        toBlock: headBlockId,
+        addresses: options.addresses,
+        keys: options.keys,
+        chunkSize: options.chunkSize,
+        cursor: backfillCursor,
+        signal: options.signal,
+      })) {
+        if (message.type === "event") {
+          if (!shouldYieldEvent(message.cursor, lastYieldedCursor)) {
+            continue;
+          }
+
+          lastYieldedCursor = message.cursor;
+          lastRealCursor = message.cursor;
+        }
+
+        yield message;
+      }
+
+      throwIfAborted(options.signal);
+
+      backfillFromBlock = undefined;
+      backfillCursor = lastRealCursor;
+
+      subscription = subscribeEvents({
+        url: options.wsUrl,
+        blockId: headBlockId,
+        addresses: options.addresses,
+        keys: options.keys,
+        finalityStatus: options.finalityStatus,
+        cursor: lastRealCursor,
+        signal: options.signal,
+        webSocketFactory: options.webSocketFactory,
+      });
+
+      const reorg = yield* yieldFromSubscription(
+        subscription,
+        lastYieldedCursor,
+      );
+      subscription = undefined;
+
+      if (!reorg) {
+        return;
+      }
+
+      const startingBlockNumber = reorg.reorg.startingBlockNumber;
+      lastYieldedCursor = cursorBeforeBlock(startingBlockNumber);
+      lastRealCursor = undefined;
+      backfillFromBlock = { block_number: startingBlockNumber };
+      backfillCursor = undefined;
+
+      yield reorg;
+    }
+  } finally {
+    if (subscription) {
+      await subscription.unsubscribe();
+    }
+  }
+}
+
+async function* yieldFromSubscription(
+  subscription: EventSubscription,
+  initialCursor: EventCursor | undefined,
+): AsyncGenerator<StreamMessage, ReorgMessage | undefined> {
+  let lastYieldedCursor = initialCursor;
+
+  for await (const message of subscription) {
+    if (message.type === "reorg") {
+      await subscription.unsubscribe();
+      return message;
+    }
+
+    if (!shouldYieldEvent(message.cursor, lastYieldedCursor)) {
+      continue;
+    }
+
+    lastYieldedCursor = message.cursor;
+    yield message;
+  }
+
+  return undefined;
+}
+
+function shouldYieldEvent(
+  cursor: EventCursor,
+  lastYieldedCursor: EventCursor | undefined,
+): boolean {
+  return (
+    lastYieldedCursor === undefined ||
+    compareEventCursor(cursor, lastYieldedCursor) > 0
+  );
+}
+
+function cursorBeforeBlock(blockNumber: number): EventCursor {
+  // Synthetic in-memory cursor used only for local dedupe after a rollback.
+  return {
+    blockNumber,
+    transactionHash: "0x0",
+    eventIndex: -1,
+  };
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw signal.reason ?? new Error("The operation was aborted.");
+  }
+}

--- a/packages/starknet-rpc/src/stream.ts
+++ b/packages/starknet-rpc/src/stream.ts
@@ -130,6 +130,7 @@ function cursorBeforeBlock(blockNumber: number): EventCursor {
   // Synthetic in-memory cursor used only for local dedupe after a rollback.
   return {
     blockNumber,
+    transactionIndex: -1,
     transactionHash: "0x0",
     eventIndex: -1,
   };

--- a/packages/starknet-rpc/src/subscribe.ts
+++ b/packages/starknet-rpc/src/subscribe.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_SUBSCRIPTION_FINALITY_STATUS } from "./constants";
 import { compareEventCursor, eventCursorKey, eventVersionKey } from "./cursor";
-import { normalizeFelt } from "./normalize";
+import { StarknetEventCursorError, normalizeFelt } from "./normalize";
 import type {
   EventCursor,
   EventSubscription,
@@ -19,6 +19,7 @@ type ReconnectConfig = {
   enabled: boolean;
   minDelayMs: number;
   maxDelayMs: number;
+  maxAttempts?: number;
 };
 
 export function subscribeEvents(
@@ -83,9 +84,11 @@ async function* subscribeWithReconnect({
   let lastCursor = options.cursor;
   let blockId = initialBlockId(options);
   let attempt = 0;
+  let lastError: unknown;
 
   while (!signal.aborted && !isUnsubscribed()) {
     let yieldedMessage = false;
+    lastError = undefined;
 
     try {
       for await (const message of connectSubscribeEvents({
@@ -106,7 +109,6 @@ async function* subscribeWithReconnect({
 
           blockId = { block_number: message.reorg.startingBlockNumber };
           yieldedMessage = true;
-          attempt = 0;
           yield message;
           continue;
         }
@@ -123,7 +125,6 @@ async function* subscribeWithReconnect({
         blockId = { block_number: message.cursor.blockNumber };
         seenEvents.remember(key, version);
         yieldedMessage = true;
-        attempt = 0;
         yield message;
       }
     } catch (error) {
@@ -135,9 +136,15 @@ async function* subscribeWithReconnect({
         throw error;
       }
 
+      if (error instanceof StarknetEventCursorError) {
+        throw error;
+      }
+
       if (!reconnect.enabled) {
         throw error;
       }
+
+      lastError = error;
     }
 
     if (signal.aborted || isUnsubscribed()) {
@@ -149,6 +156,13 @@ async function* subscribeWithReconnect({
     }
 
     attempt = yieldedMessage ? 1 : attempt + 1;
+    if (
+      reconnect.maxAttempts !== undefined &&
+      attempt > reconnect.maxAttempts
+    ) {
+      throw reconnectAttemptsExceededError(reconnect.maxAttempts, lastError);
+    }
+
     await waitForReconnect(reconnectDelayMs(reconnect, attempt), signal);
   }
 }
@@ -232,6 +246,7 @@ function normalizeReconnectConfig(
       enabled: false,
       minDelayMs: DEFAULT_MIN_RECONNECT_DELAY_MS,
       maxDelayMs: DEFAULT_MAX_RECONNECT_DELAY_MS,
+      maxAttempts: undefined,
     };
   }
 
@@ -240,6 +255,7 @@ function normalizeReconnectConfig(
       enabled: false,
       minDelayMs: DEFAULT_MIN_RECONNECT_DELAY_MS,
       maxDelayMs: DEFAULT_MAX_RECONNECT_DELAY_MS,
+      maxAttempts: undefined,
     };
   }
 
@@ -251,12 +267,40 @@ function normalizeReconnectConfig(
     typeof reconnect === "object" && reconnect.maxDelayMs !== undefined
       ? Math.max(minDelayMs, reconnect.maxDelayMs)
       : DEFAULT_MAX_RECONNECT_DELAY_MS;
+  const maxAttempts =
+    typeof reconnect === "object" && reconnect.maxAttempts !== undefined
+      ? normalizeMaxAttempts(reconnect.maxAttempts)
+      : undefined;
 
   return {
     enabled: true,
     minDelayMs,
     maxDelayMs: Math.max(minDelayMs, maxDelayMs),
+    maxAttempts,
   };
+}
+
+function normalizeMaxAttempts(value: number): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error("reconnect.maxAttempts must be a non-negative integer");
+  }
+
+  return value;
+}
+
+function reconnectAttemptsExceededError(
+  maxAttempts: number,
+  cause: unknown,
+): Error {
+  const error = new Error(
+    `WebSocket subscription reconnect attempts exceeded ${maxAttempts}`,
+  );
+
+  if (cause !== undefined) {
+    return Object.assign(error, { cause });
+  }
+
+  return error;
 }
 
 function reconnectDelayMs(

--- a/packages/starknet-rpc/src/subscribe.ts
+++ b/packages/starknet-rpc/src/subscribe.ts
@@ -1,0 +1,324 @@
+import { compareEventCursor, cursorEquals, eventCursorKey } from "./cursor";
+import { normalizeFelt } from "./normalize";
+import type {
+  BlockId,
+  EventCursor,
+  EventSubscription,
+  Felt,
+  FinalityStatus,
+  StreamMessage,
+  SubscribeEventsOptions,
+} from "./types";
+import { TooManyBlocksBackError, connectSubscribeEvents } from "./ws";
+
+const DEFAULT_FINALITY_STATUS: FinalityStatus = "ACCEPTED_ON_L2";
+const DEFAULT_MIN_RECONNECT_DELAY_MS = 500;
+const DEFAULT_MAX_RECONNECT_DELAY_MS = 10_000;
+const MAX_REMEMBERED_CURSOR_KEYS = 2_048;
+
+type ReconnectConfig = {
+  enabled: boolean;
+  minDelayMs: number;
+  maxDelayMs: number;
+};
+
+export function subscribeEvents(
+  options: SubscribeEventsOptions,
+): EventSubscription {
+  const controller = new AbortController();
+  let unsubscribed = false;
+
+  const abortFromParent = () => {
+    unsubscribed = true;
+    controller.abort(options.signal?.reason);
+  };
+
+  if (options.signal?.aborted) {
+    abortFromParent();
+  } else {
+    options.signal?.addEventListener("abort", abortFromParent, {
+      once: true,
+    });
+  }
+
+  const subscription: EventSubscription = {
+    async unsubscribe() {
+      if (unsubscribed) {
+        return;
+      }
+
+      unsubscribed = true;
+      options.signal?.removeEventListener?.("abort", abortFromParent);
+      controller.abort(new Error("Subscription unsubscribed"));
+    },
+
+    async *[Symbol.asyncIterator]() {
+      try {
+        yield* subscribeWithReconnect({
+          options: normalizeSubscribeOptions(options),
+          signal: controller.signal,
+          isUnsubscribed: () => unsubscribed,
+        });
+      } finally {
+        unsubscribed = true;
+        options.signal?.removeEventListener?.("abort", abortFromParent);
+        controller.abort(new Error("Subscription iterator closed"));
+      }
+    },
+  };
+
+  return subscription;
+}
+
+async function* subscribeWithReconnect({
+  options,
+  signal,
+  isUnsubscribed,
+}: {
+  options: SubscribeEventsOptions;
+  signal: AbortSignal;
+  isUnsubscribed: () => boolean;
+}): AsyncGenerator<StreamMessage> {
+  const reconnect = normalizeReconnectConfig(options.reconnect);
+  const seenCursorKeys = new RememberedCursorKeys(MAX_REMEMBERED_CURSOR_KEYS);
+  let lastCursor = options.cursor;
+  let blockId = initialBlockId(options);
+  let attempt = 0;
+
+  if (lastCursor) {
+    seenCursorKeys.remember(eventCursorKey(lastCursor));
+  }
+
+  while (!signal.aborted && !isUnsubscribed()) {
+    let receivedMessage = false;
+
+    try {
+      for await (const message of connectSubscribeEvents({
+        ...options,
+        blockId,
+        cursor: undefined,
+        reconnect: undefined,
+        signal,
+      })) {
+        receivedMessage = true;
+        attempt = 0;
+
+        if (message.type === "reorg") {
+          if (
+            lastCursor &&
+            lastCursor.blockNumber >= message.reorg.startingBlockNumber
+          ) {
+            lastCursor = undefined;
+            seenCursorKeys.clear();
+          }
+
+          blockId = { block_number: message.reorg.startingBlockNumber };
+          yield message;
+          continue;
+        }
+
+        const key = eventCursorKey(message.cursor);
+        if (shouldSkipEvent(message.cursor, key, lastCursor, seenCursorKeys)) {
+          continue;
+        }
+
+        lastCursor = message.cursor;
+        blockId = { block_number: message.cursor.blockNumber };
+        seenCursorKeys.remember(key);
+        yield message;
+      }
+    } catch (error) {
+      if (signal.aborted || isUnsubscribed()) {
+        return;
+      }
+
+      if (error instanceof TooManyBlocksBackError) {
+        throw error;
+      }
+
+      if (!reconnect.enabled) {
+        throw error;
+      }
+    }
+
+    if (signal.aborted || isUnsubscribed()) {
+      return;
+    }
+
+    if (!reconnect.enabled) {
+      return;
+    }
+
+    attempt = receivedMessage ? 1 : attempt + 1;
+    await waitForReconnect(reconnectDelayMs(reconnect, attempt), signal);
+  }
+}
+
+function normalizeSubscribeOptions(
+  options: SubscribeEventsOptions,
+): SubscribeEventsOptions {
+  return {
+    ...options,
+    blockId: options.blockId ? normalizeBlockId(options.blockId) : undefined,
+    addresses: normalizeFelts(options.addresses),
+    keys: options.keys?.map((keys) => normalizeFelts(keys) ?? []),
+    finalityStatus: options.finalityStatus ?? DEFAULT_FINALITY_STATUS,
+  };
+}
+
+function initialBlockId(options: SubscribeEventsOptions): BlockId {
+  if (options.blockId) {
+    return options.blockId;
+  }
+
+  if (options.cursor) {
+    return { block_number: options.cursor.blockNumber };
+  }
+
+  return "latest";
+}
+
+function normalizeBlockId(blockId: BlockId): BlockId {
+  if (typeof blockId === "string") {
+    return blockId;
+  }
+
+  if ("block_hash" in blockId) {
+    return { block_hash: normalizeFelt(blockId.block_hash) };
+  }
+
+  return blockId;
+}
+
+function normalizeFelts(values?: Felt[]): Felt[] | undefined {
+  if (!values) {
+    return undefined;
+  }
+
+  return Array.from(
+    new Set(values.map((value) => normalizeFelt(value, "subscription.filter"))),
+  );
+}
+
+function shouldSkipEvent(
+  cursor: EventCursor,
+  key: string,
+  lastCursor: EventCursor | undefined,
+  seenCursorKeys: RememberedCursorKeys,
+): boolean {
+  if (seenCursorKeys.has(key)) {
+    return true;
+  }
+
+  if (!lastCursor) {
+    return false;
+  }
+
+  if (cursorEquals(cursor, lastCursor)) {
+    return true;
+  }
+
+  return compareEventCursor(cursor, lastCursor) < 0;
+}
+
+function normalizeReconnectConfig(
+  reconnect: SubscribeEventsOptions["reconnect"],
+): ReconnectConfig {
+  if (reconnect === false) {
+    return {
+      enabled: false,
+      minDelayMs: DEFAULT_MIN_RECONNECT_DELAY_MS,
+      maxDelayMs: DEFAULT_MAX_RECONNECT_DELAY_MS,
+    };
+  }
+
+  if (typeof reconnect === "object" && reconnect.enabled === false) {
+    return {
+      enabled: false,
+      minDelayMs: DEFAULT_MIN_RECONNECT_DELAY_MS,
+      maxDelayMs: DEFAULT_MAX_RECONNECT_DELAY_MS,
+    };
+  }
+
+  const minDelayMs =
+    typeof reconnect === "object" && reconnect.minDelayMs !== undefined
+      ? Math.max(0, reconnect.minDelayMs)
+      : DEFAULT_MIN_RECONNECT_DELAY_MS;
+  const maxDelayMs =
+    typeof reconnect === "object" && reconnect.maxDelayMs !== undefined
+      ? Math.max(minDelayMs, reconnect.maxDelayMs)
+      : DEFAULT_MAX_RECONNECT_DELAY_MS;
+
+  return {
+    enabled: true,
+    minDelayMs,
+    maxDelayMs: Math.max(minDelayMs, maxDelayMs),
+  };
+}
+
+function reconnectDelayMs(
+  { minDelayMs, maxDelayMs }: ReconnectConfig,
+  attempt: number,
+): number {
+  const exponentialDelay = minDelayMs * 2 ** Math.max(0, attempt - 1);
+  const boundedDelay = Math.min(exponentialDelay, maxDelayMs);
+  const jitter = Math.random() * boundedDelay * 0.2;
+
+  return Math.min(maxDelayMs, Math.round(boundedDelay + jitter));
+}
+
+async function waitForReconnect(
+  delayMs: number,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted || delayMs <= 0) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    };
+
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+class RememberedCursorKeys {
+  private readonly keys = new Set<string>();
+  private readonly order: string[] = [];
+
+  constructor(private readonly maxSize: number) {}
+
+  has(key: string): boolean {
+    return this.keys.has(key);
+  }
+
+  remember(key: string): void {
+    if (this.keys.has(key)) {
+      return;
+    }
+
+    this.keys.add(key);
+    this.order.push(key);
+
+    while (this.order.length > this.maxSize) {
+      const oldest = this.order.shift();
+      if (oldest) {
+        this.keys.delete(oldest);
+      }
+    }
+  }
+
+  clear(): void {
+    this.keys.clear();
+    this.order.length = 0;
+  }
+}

--- a/packages/starknet-rpc/src/subscribe.ts
+++ b/packages/starknet-rpc/src/subscribe.ts
@@ -11,7 +11,7 @@ import type {
 } from "./types";
 import { TooManyBlocksBackError, connectSubscribeEvents } from "./ws";
 
-const DEFAULT_FINALITY_STATUS: FinalityStatus = "ACCEPTED_ON_L2";
+const DEFAULT_FINALITY_STATUS: FinalityStatus = "PRE_CONFIRMED";
 const DEFAULT_MIN_RECONNECT_DELAY_MS = 500;
 const DEFAULT_MAX_RECONNECT_DELAY_MS = 10_000;
 const MAX_REMEMBERED_CURSOR_KEYS = 2_048;

--- a/packages/starknet-rpc/src/subscribe.ts
+++ b/packages/starknet-rpc/src/subscribe.ts
@@ -1,17 +1,16 @@
+import { DEFAULT_SUBSCRIPTION_FINALITY_STATUS } from "./constants";
 import { compareEventCursor, cursorEquals, eventCursorKey } from "./cursor";
 import { normalizeFelt } from "./normalize";
 import type {
-  BlockId,
   EventCursor,
   EventSubscription,
   Felt,
-  FinalityStatus,
   StreamMessage,
   SubscribeEventsOptions,
+  SubscriptionBlockId,
 } from "./types";
 import { TooManyBlocksBackError, connectSubscribeEvents } from "./ws";
 
-const DEFAULT_FINALITY_STATUS: FinalityStatus = "PRE_CONFIRMED";
 const DEFAULT_MIN_RECONNECT_DELAY_MS = 500;
 const DEFAULT_MAX_RECONNECT_DELAY_MS = 10_000;
 const MAX_REMEMBERED_CURSOR_KEYS = 2_048;
@@ -163,11 +162,12 @@ function normalizeSubscribeOptions(
     blockId: options.blockId ? normalizeBlockId(options.blockId) : undefined,
     addresses: normalizeFelts(options.addresses),
     keys: options.keys?.map((keys) => normalizeFelts(keys) ?? []),
-    finalityStatus: options.finalityStatus ?? DEFAULT_FINALITY_STATUS,
+    finalityStatus:
+      options.finalityStatus ?? DEFAULT_SUBSCRIPTION_FINALITY_STATUS,
   };
 }
 
-function initialBlockId(options: SubscribeEventsOptions): BlockId {
+function initialBlockId(options: SubscribeEventsOptions): SubscriptionBlockId {
   if (options.blockId) {
     return options.blockId;
   }
@@ -179,9 +179,15 @@ function initialBlockId(options: SubscribeEventsOptions): BlockId {
   return "latest";
 }
 
-function normalizeBlockId(blockId: BlockId): BlockId {
+function normalizeBlockId(blockId: SubscriptionBlockId): SubscriptionBlockId {
   if (typeof blockId === "string") {
-    return blockId;
+    if (blockId !== "latest") {
+      throw new Error(
+        `Invalid starknet_subscribeEvents blockId tag "${blockId}". Use "latest", block_number, or block_hash.`,
+      );
+    }
+
+    return "latest";
   }
 
   if ("block_hash" in blockId) {

--- a/packages/starknet-rpc/src/subscribe.ts
+++ b/packages/starknet-rpc/src/subscribe.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_SUBSCRIPTION_FINALITY_STATUS } from "./constants";
-import { compareEventCursor, cursorEquals, eventCursorKey } from "./cursor";
+import { compareEventCursor, eventCursorKey, eventVersionKey } from "./cursor";
 import { normalizeFelt } from "./normalize";
 import type {
   EventCursor,
@@ -79,14 +79,10 @@ async function* subscribeWithReconnect({
   isUnsubscribed: () => boolean;
 }): AsyncGenerator<StreamMessage> {
   const reconnect = normalizeReconnectConfig(options.reconnect);
-  const seenCursorKeys = new RememberedCursorKeys(MAX_REMEMBERED_CURSOR_KEYS);
+  const seenEvents = new RememberedEventVersions(MAX_REMEMBERED_CURSOR_KEYS);
   let lastCursor = options.cursor;
   let blockId = initialBlockId(options);
   let attempt = 0;
-
-  if (lastCursor) {
-    seenCursorKeys.remember(eventCursorKey(lastCursor));
-  }
 
   while (!signal.aborted && !isUnsubscribed()) {
     let yieldedMessage = false;
@@ -105,7 +101,7 @@ async function* subscribeWithReconnect({
             lastCursor.blockNumber >= message.reorg.startingBlockNumber
           ) {
             lastCursor = undefined;
-            seenCursorKeys.clear();
+            seenEvents.clear();
           }
 
           blockId = { block_number: message.reorg.startingBlockNumber };
@@ -116,13 +112,16 @@ async function* subscribeWithReconnect({
         }
 
         const key = eventCursorKey(message.cursor);
-        if (shouldSkipEvent(message.cursor, key, lastCursor, seenCursorKeys)) {
+        const version = eventVersionKey(message.event);
+        if (
+          shouldSkipEvent(message.cursor, key, version, lastCursor, seenEvents)
+        ) {
           continue;
         }
 
         lastCursor = message.cursor;
         blockId = { block_number: message.cursor.blockNumber };
-        seenCursorKeys.remember(key);
+        seenEvents.remember(key, version);
         yieldedMessage = true;
         attempt = 0;
         yield message;
@@ -210,19 +209,16 @@ function normalizeFelts(values?: Felt[]): Felt[] | undefined {
 function shouldSkipEvent(
   cursor: EventCursor,
   key: string,
+  version: string,
   lastCursor: EventCursor | undefined,
-  seenCursorKeys: RememberedCursorKeys,
+  seenEvents: RememberedEventVersions,
 ): boolean {
-  if (seenCursorKeys.has(key)) {
+  if (seenEvents.has(key, version)) {
     return true;
   }
 
   if (!lastCursor) {
     return false;
-  }
-
-  if (cursorEquals(cursor, lastCursor)) {
-    return true;
   }
 
   return compareEventCursor(cursor, lastCursor) < 0;
@@ -298,34 +294,41 @@ async function waitForReconnect(
   });
 }
 
-class RememberedCursorKeys {
-  private readonly keys = new Set<string>();
+class RememberedEventVersions {
+  private readonly versions = new Map<string, Set<string>>();
   private readonly order: string[] = [];
 
   constructor(private readonly maxSize: number) {}
 
-  has(key: string): boolean {
-    return this.keys.has(key);
+  has(key: string, version: string): boolean {
+    return this.versions.get(key)?.has(version) ?? false;
   }
 
-  remember(key: string): void {
-    if (this.keys.has(key)) {
+  remember(key: string, version: string): void {
+    const versions = this.versions.get(key) ?? new Set<string>();
+    if (versions.has(version)) {
       return;
     }
 
-    this.keys.add(key);
-    this.order.push(key);
+    versions.add(version);
+    this.versions.set(key, versions);
+    this.order.push(`${key}\0${version}`);
 
     while (this.order.length > this.maxSize) {
       const oldest = this.order.shift();
       if (oldest) {
-        this.keys.delete(oldest);
+        const [oldestKey, oldestVersion] = oldest.split("\0", 2);
+        const oldestVersions = this.versions.get(oldestKey);
+        oldestVersions?.delete(oldestVersion);
+        if (oldestVersions?.size === 0) {
+          this.versions.delete(oldestKey);
+        }
       }
     }
   }
 
   clear(): void {
-    this.keys.clear();
+    this.versions.clear();
     this.order.length = 0;
   }
 }

--- a/packages/starknet-rpc/src/subscribe.ts
+++ b/packages/starknet-rpc/src/subscribe.ts
@@ -90,7 +90,7 @@ async function* subscribeWithReconnect({
   }
 
   while (!signal.aborted && !isUnsubscribed()) {
-    let receivedMessage = false;
+    let yieldedMessage = false;
 
     try {
       for await (const message of connectSubscribeEvents({
@@ -100,9 +100,6 @@ async function* subscribeWithReconnect({
         reconnect: undefined,
         signal,
       })) {
-        receivedMessage = true;
-        attempt = 0;
-
         if (message.type === "reorg") {
           if (
             lastCursor &&
@@ -113,6 +110,8 @@ async function* subscribeWithReconnect({
           }
 
           blockId = { block_number: message.reorg.startingBlockNumber };
+          yieldedMessage = true;
+          attempt = 0;
           yield message;
           continue;
         }
@@ -125,6 +124,8 @@ async function* subscribeWithReconnect({
         lastCursor = message.cursor;
         blockId = { block_number: message.cursor.blockNumber };
         seenCursorKeys.remember(key);
+        yieldedMessage = true;
+        attempt = 0;
         yield message;
       }
     } catch (error) {
@@ -149,7 +150,7 @@ async function* subscribeWithReconnect({
       return;
     }
 
-    attempt = receivedMessage ? 1 : attempt + 1;
+    attempt = yieldedMessage ? 1 : attempt + 1;
     await waitForReconnect(reconnectDelayMs(reconnect, attempt), signal);
   }
 }

--- a/packages/starknet-rpc/src/types.ts
+++ b/packages/starknet-rpc/src/types.ts
@@ -18,6 +18,7 @@ export type FinalityStatus =
 
 export interface EventCursor {
   blockNumber: number;
+  transactionIndex: number;
   transactionHash: Felt;
   eventIndex: number;
 }
@@ -42,7 +43,7 @@ export interface NormalizedEvent {
   blockHash?: Felt;
   blockNumber: number;
   transactionHash: Felt;
-  transactionIndex?: number;
+  transactionIndex: number;
   eventIndex: number;
   finalityStatus?: FinalityStatus;
   raw: RpcEvent;

--- a/packages/starknet-rpc/src/types.ts
+++ b/packages/starknet-rpc/src/types.ts
@@ -124,6 +124,10 @@ export interface SubscribeEventsOptions {
   finalityStatus?: SubscriptionFinalityStatus;
   cursor?: EventCursor;
   reconnect?: boolean | SubscribeReconnectOptions;
+  /** Close and reconnect when no WebSocket frames are received for this many milliseconds. Set to 0 to disable. */
+  idleTimeoutMs?: number;
+  /** Maximum queued WebSocket messages waiting for the consumer before the subscription is closed. */
+  maxQueueSize?: number;
   signal?: AbortSignal;
   webSocketFactory?: WebSocketFactory;
 }
@@ -132,6 +136,8 @@ export interface SubscribeReconnectOptions {
   enabled?: boolean;
   minDelayMs?: number;
   maxDelayMs?: number;
+  /** Maximum reconnect attempts after a failed or closed connection. Omit for no limit. */
+  maxAttempts?: number;
 }
 
 export interface EventSubscription extends AsyncIterable<StreamMessage> {
@@ -146,6 +152,10 @@ export interface StreamEventsOptions extends Omit<EventFilter, "toBlock"> {
   cursorFinalityStatus?: FinalityStatus;
   /** Applies to the live WebSocket subscription. Historical backfill uses accepted events. */
   finalityStatus?: SubscriptionFinalityStatus;
+  /** Close and reconnect when no WebSocket frames are received for this many milliseconds. Set to 0 to disable. */
+  idleTimeoutMs?: number;
+  /** Maximum queued WebSocket messages waiting for the consumer before the subscription is closed. */
+  maxQueueSize?: number;
   signal?: AbortSignal;
   webSocketFactory?: WebSocketFactory;
 }

--- a/packages/starknet-rpc/src/types.ts
+++ b/packages/starknet-rpc/src/types.ts
@@ -125,10 +125,11 @@ export interface EventSubscription extends AsyncIterable<StreamMessage> {
   unsubscribe(): Promise<void>;
 }
 
-export interface StreamEventsOptions extends EventFilter {
+export interface StreamEventsOptions extends Omit<EventFilter, "toBlock"> {
   url: string;
   wsUrl: string;
   cursor?: EventCursor;
+  /** Applies to the live WebSocket subscription. Historical backfill uses accepted events. */
   finalityStatus?: FinalityStatus;
   signal?: AbortSignal;
   webSocketFactory?: WebSocketFactory;

--- a/packages/starknet-rpc/src/types.ts
+++ b/packages/starknet-rpc/src/types.ts
@@ -142,6 +142,8 @@ export interface StreamEventsOptions extends Omit<EventFilter, "toBlock"> {
   url: string;
   wsUrl: string;
   cursor?: EventCursor;
+  /** Finality of the persisted cursor, when known. Unknown cursors are replayed conservatively for pre-confirmed live streams. */
+  cursorFinalityStatus?: FinalityStatus;
   /** Applies to the live WebSocket subscription. Historical backfill uses accepted events. */
   finalityStatus?: SubscriptionFinalityStatus;
   signal?: AbortSignal;

--- a/packages/starknet-rpc/src/types.ts
+++ b/packages/starknet-rpc/src/types.ts
@@ -1,0 +1,163 @@
+export type Felt = string;
+
+export type BlockTag = "latest" | "pending" | "l1_accepted" | "pre_confirmed";
+
+export type BlockId =
+  | BlockTag
+  | {
+      block_number: number;
+    }
+  | {
+      block_hash: Felt;
+    };
+
+export type FinalityStatus =
+  | "ACCEPTED_ON_L2"
+  | "ACCEPTED_ON_L1"
+  | "PRE_CONFIRMED";
+
+export interface EventCursor {
+  blockNumber: number;
+  transactionHash: Felt;
+  eventIndex: number;
+}
+
+export interface RpcEvent {
+  from_address: Felt;
+  keys: Felt[];
+  data: Felt[];
+  block_hash?: Felt;
+  block_number?: number;
+  transaction_hash: Felt;
+  transaction_index?: number;
+  event_index?: number;
+  finality_status?: FinalityStatus;
+}
+
+export interface NormalizedEvent {
+  cursor: EventCursor;
+  fromAddress: Felt;
+  keys: Felt[];
+  data: Felt[];
+  blockHash?: Felt;
+  blockNumber: number;
+  transactionHash: Felt;
+  transactionIndex?: number;
+  eventIndex: number;
+  finalityStatus?: FinalityStatus;
+  raw: RpcEvent;
+}
+
+export interface RpcReorg {
+  starting_block_number: number;
+  starting_block_hash: Felt;
+  ending_block_number: number;
+  ending_block_hash: Felt;
+}
+
+export interface NormalizedReorg {
+  startingBlockNumber: number;
+  startingBlockHash: Felt;
+  endingBlockNumber: number;
+  endingBlockHash: Felt;
+  raw: RpcReorg;
+}
+
+export type EventMessage = {
+  type: "event";
+  event: NormalizedEvent;
+  cursor: EventCursor;
+};
+
+export type ReorgMessage = {
+  type: "reorg";
+  reorg: NormalizedReorg;
+};
+
+export type StreamMessage = EventMessage | ReorgMessage;
+
+export interface EventFilter {
+  fromBlock?: BlockId;
+  toBlock?: BlockId;
+  addresses?: Felt[];
+  keys?: Felt[][];
+  chunkSize?: number;
+}
+
+export interface GetEventsOptions extends EventFilter {
+  url: string;
+  continuationToken?: string;
+  signal?: AbortSignal;
+}
+
+export interface GetEventsPage {
+  events: NormalizedEvent[];
+  continuationToken?: string;
+}
+
+export interface BackfillEventsOptions extends EventFilter {
+  url: string;
+  cursor?: EventCursor;
+  continuationToken?: string;
+  signal?: AbortSignal;
+}
+
+export interface SubscribeEventsOptions {
+  url: string;
+  blockId?: BlockId;
+  addresses?: Felt[];
+  keys?: Felt[][];
+  finalityStatus?: FinalityStatus;
+  cursor?: EventCursor;
+  reconnect?: boolean | SubscribeReconnectOptions;
+  signal?: AbortSignal;
+  webSocketFactory?: WebSocketFactory;
+}
+
+export interface SubscribeReconnectOptions {
+  enabled?: boolean;
+  minDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+export interface EventSubscription extends AsyncIterable<StreamMessage> {
+  unsubscribe(): Promise<void>;
+}
+
+export interface StreamEventsOptions extends EventFilter {
+  url: string;
+  wsUrl: string;
+  cursor?: EventCursor;
+  finalityStatus?: FinalityStatus;
+  signal?: AbortSignal;
+  webSocketFactory?: WebSocketFactory;
+}
+
+export interface BlockMetadata {
+  blockNumber: number;
+  blockHash: Felt;
+  timestamp: number;
+}
+
+export interface BlockCacheOptions {
+  url: string;
+  signal?: AbortSignal;
+}
+
+export interface RpcWebSocket {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(
+    type: "open" | "message" | "error" | "close",
+    listener: (event: unknown) => void,
+    options?: unknown,
+  ): void;
+  removeEventListener?(
+    type: "open" | "message" | "error" | "close",
+    listener: (event: unknown) => void,
+    options?: unknown,
+  ): void;
+  readyState?: number;
+}
+
+export type WebSocketFactory = (url: string) => RpcWebSocket;

--- a/packages/starknet-rpc/src/types.ts
+++ b/packages/starknet-rpc/src/types.ts
@@ -11,10 +11,21 @@ export type BlockId =
       block_hash: Felt;
     };
 
+export type SubscriptionBlockId =
+  | "latest"
+  | {
+      block_number: number;
+    }
+  | {
+      block_hash: Felt;
+    };
+
 export type FinalityStatus =
   | "ACCEPTED_ON_L2"
   | "ACCEPTED_ON_L1"
   | "PRE_CONFIRMED";
+
+export type SubscriptionFinalityStatus = "ACCEPTED_ON_L2" | "PRE_CONFIRMED";
 
 export interface EventCursor {
   blockNumber: number;
@@ -105,10 +116,10 @@ export interface BackfillEventsOptions extends EventFilter {
 
 export interface SubscribeEventsOptions {
   url: string;
-  blockId?: BlockId;
+  blockId?: SubscriptionBlockId;
   addresses?: Felt[];
   keys?: Felt[][];
-  finalityStatus?: FinalityStatus;
+  finalityStatus?: SubscriptionFinalityStatus;
   cursor?: EventCursor;
   reconnect?: boolean | SubscribeReconnectOptions;
   signal?: AbortSignal;
@@ -130,7 +141,7 @@ export interface StreamEventsOptions extends Omit<EventFilter, "toBlock"> {
   wsUrl: string;
   cursor?: EventCursor;
   /** Applies to the live WebSocket subscription. Historical backfill uses accepted events. */
-  finalityStatus?: FinalityStatus;
+  finalityStatus?: SubscriptionFinalityStatus;
   signal?: AbortSignal;
   webSocketFactory?: WebSocketFactory;
 }

--- a/packages/starknet-rpc/src/types.ts
+++ b/packages/starknet-rpc/src/types.ts
@@ -1,6 +1,6 @@
 export type Felt = string;
 
-export type BlockTag = "latest" | "pending" | "l1_accepted" | "pre_confirmed";
+export type BlockTag = "latest" | "l1_accepted" | "pre_confirmed";
 
 export type BlockId =
   | BlockTag
@@ -72,6 +72,7 @@ export interface NormalizedReorg {
   startingBlockHash: Felt;
   endingBlockNumber: number;
   endingBlockHash: Felt;
+  synthetic?: boolean;
   raw: RpcReorg;
 }
 
@@ -84,6 +85,7 @@ export type EventMessage = {
 export type ReorgMessage = {
   type: "reorg";
   reorg: NormalizedReorg;
+  rollbackCursor: EventCursor;
 };
 
 export type StreamMessage = EventMessage | ReorgMessage;

--- a/packages/starknet-rpc/src/ws.ts
+++ b/packages/starknet-rpc/src/ws.ts
@@ -94,7 +94,19 @@ export async function* connectSubscribeEvents(
       }),
     );
 
-    subscriptionId = await waitForSubscriptionId(queue, requestId);
+    const pendingMessages: unknown[] = [];
+    subscriptionId = await waitForSubscriptionId(
+      queue,
+      requestId,
+      pendingMessages,
+    );
+
+    for (const pendingMessage of pendingMessages) {
+      const message = parseNotification(pendingMessage, subscriptionId);
+      if (message) {
+        yield message;
+      }
+    }
 
     while (true) {
       const next = await queue.next();
@@ -255,6 +267,7 @@ async function waitForOpen(
 async function waitForSubscriptionId(
   queue: AsyncMessageQueue<unknown>,
   requestId: JsonRpcId,
+  pendingMessages: unknown[],
 ): Promise<unknown> {
   while (true) {
     const next = await queue.next();
@@ -264,6 +277,7 @@ async function waitForSubscriptionId(
 
     const response = asResponseFor(next.value, requestId);
     if (!response) {
+      pendingMessages.push(next.value);
       continue;
     }
 
@@ -499,8 +513,8 @@ class AsyncMessageQueue<T> {
   }
 
   async next(): Promise<IteratorResult<T>> {
-    const value = this.values.shift();
-    if (value !== undefined) {
+    if (this.values.length > 0) {
+      const value = this.values.shift() as T;
       return { done: false, value };
     }
 

--- a/packages/starknet-rpc/src/ws.ts
+++ b/packages/starknet-rpc/src/ws.ts
@@ -1,5 +1,6 @@
 import WebSocketImpl from "ws";
 import { DEFAULT_SUBSCRIPTION_FINALITY_STATUS } from "./constants";
+import { cursorBeforeBlock } from "./cursor";
 import { normalizeEvent, normalizeFelt, normalizeReorg } from "./normalize";
 import type {
   Felt,
@@ -344,9 +345,11 @@ function parseNotification(
     return { type: "event", event, cursor: event.cursor };
   }
 
+  const reorg = normalizeReorg(result as unknown as RpcReorg);
   return {
     type: "reorg",
-    reorg: normalizeReorg(result as unknown as RpcReorg),
+    reorg,
+    rollbackCursor: cursorBeforeBlock(reorg.startingBlockNumber),
   };
 }
 

--- a/packages/starknet-rpc/src/ws.ts
+++ b/packages/starknet-rpc/src/ws.ts
@@ -1,0 +1,519 @@
+import { normalizeEvent, normalizeFelt, normalizeReorg } from "./normalize";
+import type {
+  BlockId,
+  Felt,
+  FinalityStatus,
+  RpcEvent,
+  RpcReorg,
+  RpcWebSocket,
+  StreamMessage,
+  SubscribeEventsOptions,
+  WebSocketFactory,
+} from "./types";
+
+const DEFAULT_FINALITY_STATUS: FinalityStatus = "ACCEPTED_ON_L2";
+const TOO_MANY_BLOCKS_BACK_CODE = 68;
+const SUBSCRIBE_METHOD = "starknet_subscribeEvents";
+const EVENT_NOTIFICATION = "starknet_subscriptionEvents";
+const REORG_NOTIFICATION = "starknet_subscriptionReorg";
+const UNSUBSCRIBE_METHOD = "starknet_unsubscribe";
+
+const WS_OPEN = 1;
+const WS_CLOSED = 3;
+
+type JsonRpcId = number | string;
+
+type JsonRpcErrorPayload = {
+  code?: number;
+  message?: string;
+  data?: unknown;
+};
+
+type JsonRpcResponse = {
+  id?: JsonRpcId | null;
+  result?: unknown;
+  error?: JsonRpcErrorPayload;
+};
+
+export class TooManyBlocksBackError extends Error {
+  readonly code = TOO_MANY_BLOCKS_BACK_CODE;
+  readonly data: unknown;
+
+  constructor(
+    message = "starknet_subscribeEvents requested too much history",
+    data?: unknown,
+  ) {
+    super(message);
+    this.name = "TooManyBlocksBackError";
+    this.data = data;
+  }
+}
+
+export async function* connectSubscribeEvents(
+  options: SubscribeEventsOptions,
+): AsyncGenerator<StreamMessage> {
+  const ws = createWebSocket(options.url, options.webSocketFactory);
+  const queue = new AsyncMessageQueue<unknown>();
+  const requestId = 1;
+  const unsubscribeRequestId = 2;
+  let subscriptionId: unknown;
+
+  const closeOnAbort = () => {
+    queue.close();
+  };
+
+  const onMessage = (event: unknown) => {
+    void parseMessageEvent(event).then(
+      (message) => queue.push(message),
+      (error) => queue.close(error),
+    );
+  };
+  const onError = (event: unknown) => {
+    queue.close(toWebSocketError(event));
+  };
+  const onClose = () => {
+    queue.close();
+  };
+
+  ws.addEventListener("message", onMessage);
+  ws.addEventListener("error", onError);
+  ws.addEventListener("close", onClose);
+  options.signal?.addEventListener("abort", closeOnAbort, { once: true });
+
+  try {
+    throwIfAborted(options.signal);
+    await waitForOpen(ws, options.signal);
+    throwIfAborted(options.signal);
+
+    ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: requestId,
+        method: SUBSCRIBE_METHOD,
+        params: buildSubscribeParams(options),
+      }),
+    );
+
+    subscriptionId = await waitForSubscriptionId(queue, requestId);
+
+    while (true) {
+      const next = await queue.next();
+      if (next.done) {
+        return;
+      }
+
+      const message = parseNotification(next.value, subscriptionId);
+      if (message) {
+        yield message;
+      }
+    }
+  } finally {
+    options.signal?.removeEventListener?.("abort", closeOnAbort);
+
+    if (subscriptionId !== undefined && isOpen(ws)) {
+      try {
+        ws.send(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: unsubscribeRequestId,
+            method: UNSUBSCRIBE_METHOD,
+            params: { subscription_id: subscriptionId },
+          }),
+        );
+      } catch {
+        // Best-effort cleanup: the socket may already be closing.
+      }
+    }
+
+    ws.removeEventListener?.("message", onMessage);
+    ws.removeEventListener?.("error", onError);
+    ws.removeEventListener?.("close", onClose);
+    closeWebSocket(ws);
+  }
+}
+
+function createWebSocket(
+  url: string,
+  factory?: WebSocketFactory,
+): RpcWebSocket {
+  if (factory) {
+    return factory(url);
+  }
+
+  const WebSocketCtor = (
+    globalThis as {
+      WebSocket?: new (url: string) => RpcWebSocket;
+    }
+  ).WebSocket;
+
+  if (!WebSocketCtor) {
+    throw new Error(
+      "No WebSocket implementation available. Pass webSocketFactory in SubscribeEventsOptions.",
+    );
+  }
+
+  return new WebSocketCtor(url);
+}
+
+function buildSubscribeParams(options: SubscribeEventsOptions) {
+  const params: {
+    block_id: BlockId;
+    from_address?: Felt | Felt[];
+    keys?: Felt[][];
+    finality_status: FinalityStatus;
+  } = {
+    block_id: normalizeBlockId(options.blockId ?? "latest"),
+    finality_status: options.finalityStatus ?? DEFAULT_FINALITY_STATUS,
+  };
+
+  const fromAddress = normalizeAddresses(options.addresses);
+  if (fromAddress !== undefined) {
+    params.from_address = fromAddress;
+  }
+
+  if (options.keys) {
+    params.keys = options.keys.map((keys, position) =>
+      keys.map((key) => normalizeFelt(key, `subscription.keys[${position}]`)),
+    );
+  }
+
+  return params;
+}
+
+function normalizeBlockId(blockId: BlockId): BlockId {
+  if (typeof blockId === "string") {
+    return blockId;
+  }
+
+  if ("block_hash" in blockId) {
+    return { block_hash: normalizeFelt(blockId.block_hash) };
+  }
+
+  return blockId;
+}
+
+function normalizeAddresses(addresses?: Felt[]): Felt | Felt[] | undefined {
+  if (!addresses || addresses.length === 0) {
+    return undefined;
+  }
+
+  const normalized = Array.from(
+    new Set(
+      addresses.map((address) =>
+        normalizeFelt(address, "subscription.addresses"),
+      ),
+    ),
+  );
+  return normalized.length === 1 ? normalized[0] : normalized;
+}
+
+async function waitForOpen(
+  ws: RpcWebSocket,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (isOpen(ws)) {
+    return;
+  }
+
+  if (ws.readyState === WS_CLOSED) {
+    throw new Error("WebSocket closed before it opened");
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const onOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (event: unknown) => {
+      cleanup();
+      reject(toWebSocketError(event));
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error("WebSocket closed before it opened"));
+    };
+    const onAbort = () => {
+      cleanup();
+      resolve();
+    };
+    const cleanup = () => {
+      ws.removeEventListener?.("open", onOpen);
+      ws.removeEventListener?.("error", onError);
+      ws.removeEventListener?.("close", onClose);
+      signal?.removeEventListener?.("abort", onAbort);
+    };
+
+    ws.addEventListener("open", onOpen, { once: true });
+    ws.addEventListener("error", onError, { once: true });
+    ws.addEventListener("close", onClose, { once: true });
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+
+  throwIfAborted(signal);
+}
+
+async function waitForSubscriptionId(
+  queue: AsyncMessageQueue<unknown>,
+  requestId: JsonRpcId,
+): Promise<unknown> {
+  while (true) {
+    const next = await queue.next();
+    if (next.done) {
+      throw new Error("WebSocket closed before subscription was established");
+    }
+
+    const response = asResponseFor(next.value, requestId);
+    if (!response) {
+      continue;
+    }
+
+    if (response.error) {
+      throw toRpcError(response.error);
+    }
+
+    return response.result;
+  }
+}
+
+function parseNotification(
+  message: unknown,
+  subscriptionId: unknown,
+): StreamMessage | null {
+  if (!isRecord(message)) {
+    return null;
+  }
+
+  const { method } = message;
+  if (method !== EVENT_NOTIFICATION && method !== REORG_NOTIFICATION) {
+    return null;
+  }
+
+  const params = message.params;
+  if (!isRecord(params)) {
+    return null;
+  }
+
+  if (
+    "subscription_id" in params &&
+    !sameSubscriptionId(params.subscription_id, subscriptionId)
+  ) {
+    return null;
+  }
+
+  const result = extractNotificationResult(params, method);
+  if (!isRecord(result)) {
+    return null;
+  }
+
+  if (method === EVENT_NOTIFICATION) {
+    const event = normalizeEvent(result as unknown as RpcEvent);
+    return { type: "event", event, cursor: event.cursor };
+  }
+
+  return {
+    type: "reorg",
+    reorg: normalizeReorg(result as unknown as RpcReorg),
+  };
+}
+
+function extractNotificationResult(
+  params: Record<string, unknown>,
+  method: unknown,
+): unknown {
+  if ("result" in params) {
+    return params.result;
+  }
+
+  if (method === EVENT_NOTIFICATION && "event" in params) {
+    return params.event;
+  }
+
+  if (method === REORG_NOTIFICATION && "reorg" in params) {
+    return params.reorg;
+  }
+
+  return params;
+}
+
+async function parseMessageEvent(event: unknown): Promise<unknown> {
+  const payload = isRecord(event) && "data" in event ? event.data : event;
+  const text = await payloadToText(payload);
+  return JSON.parse(text);
+}
+
+async function payloadToText(payload: unknown): Promise<string> {
+  if (typeof payload === "string") {
+    return payload;
+  }
+
+  if (payload instanceof ArrayBuffer) {
+    return new TextDecoder().decode(payload);
+  }
+
+  if (ArrayBuffer.isView(payload)) {
+    return new TextDecoder().decode(payload);
+  }
+
+  if (isTextLikeBlob(payload)) {
+    return payload.text();
+  }
+
+  return String(payload);
+}
+
+function asResponseFor(
+  message: unknown,
+  requestId: JsonRpcId,
+): JsonRpcResponse | null {
+  if (!isRecord(message) || !("id" in message)) {
+    return null;
+  }
+
+  if (message.id !== requestId) {
+    return null;
+  }
+
+  const response: JsonRpcResponse = { id: message.id as JsonRpcId };
+  if ("result" in message) {
+    response.result = message.result;
+  }
+  if ("error" in message && isRecord(message.error)) {
+    const { code, message: errorMessage, data } = message.error;
+    response.error = {
+      code: typeof code === "number" ? code : undefined,
+      message: typeof errorMessage === "string" ? errorMessage : undefined,
+      data,
+    };
+  }
+
+  return response;
+}
+
+function toRpcError(error: JsonRpcErrorPayload): Error {
+  if (error.code === TOO_MANY_BLOCKS_BACK_CODE) {
+    return new TooManyBlocksBackError(error.message, error.data);
+  }
+
+  const rpcError = new Error(
+    `JSON-RPC error${error.code === undefined ? "" : ` ${error.code}`}: ${
+      error.message ?? "unknown error"
+    }`,
+  );
+
+  return Object.assign(rpcError, {
+    code: error.code,
+    data: error.data,
+  });
+}
+
+function sameSubscriptionId(left: unknown, right: unknown): boolean {
+  return left === right || String(left) === String(right);
+}
+
+function isOpen(ws: RpcWebSocket): boolean {
+  return ws.readyState === undefined || ws.readyState === WS_OPEN;
+}
+
+function closeWebSocket(ws: RpcWebSocket): void {
+  if (ws.readyState === WS_CLOSED) {
+    return;
+  }
+
+  try {
+    ws.close(1000, "subscription closed");
+  } catch {
+    // Closing is best effort across structural WebSocket implementations.
+  }
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw signal.reason ?? new Error("Operation aborted");
+  }
+}
+
+function toWebSocketError(event: unknown): Error {
+  if (event instanceof Error) {
+    return event;
+  }
+
+  if (isRecord(event)) {
+    if (event.error instanceof Error) {
+      return event.error;
+    }
+
+    if (typeof event.message === "string") {
+      return new Error(event.message);
+    }
+  }
+
+  return new Error("WebSocket error");
+}
+
+function isTextLikeBlob(value: unknown): value is { text(): Promise<string> } {
+  return isRecord(value) && "text" in value && typeof value.text === "function";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+class AsyncMessageQueue<T> {
+  private values: T[] = [];
+  private waiters: Array<{
+    resolve: (value: IteratorResult<T>) => void;
+    reject: (reason?: unknown) => void;
+  }> = [];
+  private closed = false;
+  private error: unknown;
+
+  push(value: T): void {
+    if (this.closed) {
+      return;
+    }
+
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter.resolve({ done: false, value });
+      return;
+    }
+
+    this.values.push(value);
+  }
+
+  close(error?: unknown): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+    this.error = error;
+
+    for (const waiter of this.waiters.splice(0)) {
+      if (error) {
+        waiter.reject(error);
+      } else {
+        waiter.resolve({ done: true, value: undefined });
+      }
+    }
+  }
+
+  async next(): Promise<IteratorResult<T>> {
+    const value = this.values.shift();
+    if (value !== undefined) {
+      return { done: false, value };
+    }
+
+    if (this.closed) {
+      if (this.error) {
+        throw this.error;
+      }
+
+      return { done: true, value: undefined };
+    }
+
+    return new Promise<IteratorResult<T>>((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
+    });
+  }
+}

--- a/packages/starknet-rpc/src/ws.ts
+++ b/packages/starknet-rpc/src/ws.ts
@@ -11,7 +11,7 @@ import type {
   WebSocketFactory,
 } from "./types";
 
-const DEFAULT_FINALITY_STATUS: FinalityStatus = "ACCEPTED_ON_L2";
+const DEFAULT_FINALITY_STATUS: FinalityStatus = "PRE_CONFIRMED";
 const TOO_MANY_BLOCKS_BACK_CODE = 68;
 const SUBSCRIBE_METHOD = "starknet_subscribeEvents";
 const EVENT_NOTIFICATION = "starknet_subscriptionEvents";

--- a/packages/starknet-rpc/src/ws.ts
+++ b/packages/starknet-rpc/src/ws.ts
@@ -22,6 +22,8 @@ const UNSUBSCRIBE_METHOD = "starknet_unsubscribe";
 
 const WS_OPEN = 1;
 const WS_CLOSED = 3;
+const DEFAULT_WS_IDLE_TIMEOUT_MS = 60_000;
+const DEFAULT_WS_MAX_QUEUE_SIZE = 10_000;
 
 type JsonRpcId = number | string;
 
@@ -51,24 +53,70 @@ export class TooManyBlocksBackError extends Error {
   }
 }
 
+export class WebSocketIdleTimeoutError extends Error {
+  constructor(readonly idleTimeoutMs: number) {
+    super(`WebSocket subscription idle for ${idleTimeoutMs}ms`);
+    this.name = "WebSocketIdleTimeoutError";
+  }
+}
+
+export class WebSocketQueueOverflowError extends Error {
+  constructor(readonly maxQueueSize: number) {
+    super(`WebSocket subscription queue exceeded ${maxQueueSize} messages`);
+    this.name = "WebSocketQueueOverflowError";
+  }
+}
+
 export async function* connectSubscribeEvents(
   options: SubscribeEventsOptions,
 ): AsyncGenerator<StreamMessage> {
+  const subscribeParams = buildSubscribeParams(options);
+  const idleTimeoutMs = normalizeIdleTimeoutMs(options.idleTimeoutMs);
+  const maxQueueSize = normalizeMaxQueueSize(options.maxQueueSize);
   const ws = createWebSocket(options.url, options.webSocketFactory);
-  const queue = new AsyncMessageQueue<unknown>();
+  const queue = new AsyncMessageQueue<unknown>(maxQueueSize);
   const requestId = 1;
   const unsubscribeRequestId = 2;
   let subscriptionId: unknown;
+  let idleTimeout: ReturnType<typeof setTimeout> | undefined;
+  let parseChain: Promise<void> = Promise.resolve();
 
   const closeOnAbort = () => {
     queue.close();
   };
+  const clearIdleTimer = () => {
+    if (idleTimeout) {
+      clearTimeout(idleTimeout);
+      idleTimeout = undefined;
+    }
+  };
+  const resetIdleTimer = () => {
+    clearIdleTimer();
+    if (idleTimeoutMs === 0) {
+      return;
+    }
+
+    idleTimeout = setTimeout(() => {
+      queue.close(new WebSocketIdleTimeoutError(idleTimeoutMs));
+      closeWebSocket(ws, 4000, "subscription idle timeout");
+    }, idleTimeoutMs);
+  };
+  const parseAndQueueMessage = async (event: unknown) => {
+    try {
+      queue.push(await parseMessageEvent(event));
+    } catch {
+      // Drop malformed transport frames. Valid JSON-RPC error responses and
+      // invalid Starknet event payloads are handled after parsing.
+    }
+  };
 
   const onMessage = (event: unknown) => {
-    void parseMessageEvent(event).then(
-      (message) => queue.push(message),
-      (error) => queue.close(error),
+    resetIdleTimer();
+    parseChain = parseChain.then(
+      () => parseAndQueueMessage(event),
+      () => parseAndQueueMessage(event),
     );
+    void parseChain;
   };
   const onError = (event: unknown) => {
     queue.close(toWebSocketError(event));
@@ -86,13 +134,14 @@ export async function* connectSubscribeEvents(
     throwIfAborted(options.signal);
     await waitForOpen(ws, options.signal);
     throwIfAborted(options.signal);
+    resetIdleTimer();
 
     ws.send(
       JSON.stringify({
         jsonrpc: "2.0",
         id: requestId,
         method: SUBSCRIBE_METHOD,
-        params: buildSubscribeParams(options),
+        params: subscribeParams,
       }),
     );
 
@@ -122,6 +171,7 @@ export async function* connectSubscribeEvents(
       }
     }
   } finally {
+    clearIdleTimer();
     options.signal?.removeEventListener?.("abort", closeOnAbort);
 
     if (subscriptionId !== undefined && isOpen(ws)) {
@@ -238,6 +288,34 @@ function normalizeAddresses(addresses?: Felt[]): Felt | Felt[] | undefined {
     ),
   );
   return normalized.length === 1 ? normalized[0] : normalized;
+}
+
+function normalizeIdleTimeoutMs(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_WS_IDLE_TIMEOUT_MS;
+  }
+
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error("idleTimeoutMs must be a non-negative integer");
+  }
+
+  return value;
+}
+
+function normalizeMaxQueueSize(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_WS_MAX_QUEUE_SIZE;
+  }
+
+  if (value === Number.POSITIVE_INFINITY) {
+    return value;
+  }
+
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error("maxQueueSize must be a positive integer");
+  }
+
+  return value;
 }
 
 async function waitForOpen(
@@ -451,13 +529,17 @@ function isOpen(ws: RpcWebSocket): boolean {
   return ws.readyState === undefined || ws.readyState === WS_OPEN;
 }
 
-function closeWebSocket(ws: RpcWebSocket): void {
+function closeWebSocket(
+  ws: RpcWebSocket,
+  code = 1000,
+  reason = "subscription closed",
+): void {
   if (ws.readyState === WS_CLOSED) {
     return;
   }
 
   try {
-    ws.close(1000, "subscription closed");
+    ws.close(code, reason);
   } catch {
     // Closing is best effort across structural WebSocket implementations.
   }
@@ -504,6 +586,8 @@ class AsyncMessageQueue<T> {
   private closed = false;
   private error: unknown;
 
+  constructor(private readonly maxSize: number) {}
+
   push(value: T): void {
     if (this.closed) {
       return;
@@ -512,6 +596,11 @@ class AsyncMessageQueue<T> {
     const waiter = this.waiters.shift();
     if (waiter) {
       waiter.resolve({ done: false, value });
+      return;
+    }
+
+    if (this.values.length >= this.maxSize) {
+      this.close(new WebSocketQueueOverflowError(this.maxSize));
       return;
     }
 

--- a/packages/starknet-rpc/src/ws.ts
+++ b/packages/starknet-rpc/src/ws.ts
@@ -1,17 +1,18 @@
+import WebSocketImpl from "ws";
+import { DEFAULT_SUBSCRIPTION_FINALITY_STATUS } from "./constants";
 import { normalizeEvent, normalizeFelt, normalizeReorg } from "./normalize";
 import type {
-  BlockId,
   Felt,
-  FinalityStatus,
   RpcEvent,
   RpcReorg,
   RpcWebSocket,
   StreamMessage,
   SubscribeEventsOptions,
+  SubscriptionBlockId,
+  SubscriptionFinalityStatus,
   WebSocketFactory,
 } from "./types";
 
-const DEFAULT_FINALITY_STATUS: FinalityStatus = "PRE_CONFIRMED";
 const TOO_MANY_BLOCKS_BACK_CODE = 68;
 const SUBSCRIBE_METHOD = "starknet_subscribeEvents";
 const EVENT_NOTIFICATION = "starknet_subscriptionEvents";
@@ -158,24 +159,22 @@ function createWebSocket(
     }
   ).WebSocket;
 
-  if (!WebSocketCtor) {
-    throw new Error(
-      "No WebSocket implementation available. Pass webSocketFactory in SubscribeEventsOptions.",
-    );
-  }
-
-  return new WebSocketCtor(url);
+  return WebSocketCtor
+    ? new WebSocketCtor(url)
+    : (new WebSocketImpl(url) as unknown as RpcWebSocket);
 }
 
 function buildSubscribeParams(options: SubscribeEventsOptions) {
   const params: {
-    block_id: BlockId;
+    block_id: SubscriptionBlockId;
     from_address?: Felt | Felt[];
     keys?: Felt[][];
-    finality_status: FinalityStatus;
+    finality_status: SubscriptionFinalityStatus;
   } = {
     block_id: normalizeBlockId(options.blockId ?? "latest"),
-    finality_status: options.finalityStatus ?? DEFAULT_FINALITY_STATUS,
+    finality_status: normalizeFinalityStatus(
+      options.finalityStatus ?? DEFAULT_SUBSCRIPTION_FINALITY_STATUS,
+    ),
   };
 
   const fromAddress = normalizeAddresses(options.addresses);
@@ -192,9 +191,15 @@ function buildSubscribeParams(options: SubscribeEventsOptions) {
   return params;
 }
 
-function normalizeBlockId(blockId: BlockId): BlockId {
+function normalizeBlockId(blockId: SubscriptionBlockId): SubscriptionBlockId {
   if (typeof blockId === "string") {
-    return blockId;
+    if (blockId !== "latest") {
+      throw new Error(
+        `Invalid starknet_subscribeEvents blockId tag "${blockId}". Use "latest", block_number, or block_hash.`,
+      );
+    }
+
+    return "latest";
   }
 
   if ("block_hash" in blockId) {
@@ -202,6 +207,21 @@ function normalizeBlockId(blockId: BlockId): BlockId {
   }
 
   return blockId;
+}
+
+function normalizeFinalityStatus(
+  finalityStatus: SubscriptionFinalityStatus,
+): SubscriptionFinalityStatus {
+  if (
+    finalityStatus !== "ACCEPTED_ON_L2" &&
+    finalityStatus !== "PRE_CONFIRMED"
+  ) {
+    throw new Error(
+      `Invalid starknet_subscribeEvents finalityStatus "${finalityStatus}". Use "ACCEPTED_ON_L2" or "PRE_CONFIRMED".`,
+    );
+  }
+
+  return finalityStatus;
 }
 
 function normalizeAddresses(addresses?: Felt[]): Felt | Felt[] | undefined {

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -155,6 +155,36 @@ describe("HTTP backfill", () => {
     ]);
   });
 
+  it("omits non-conformant multi-address RPC filters and filters client-side", async () => {
+    const requests: unknown[] = [];
+    mockRpcFetch((request) => {
+      requests.push(request);
+      return {
+        events: [
+          rawEvent({ fromAddress: "0xaaa", transactionHash: "0x1" }),
+          rawEvent({ fromAddress: "0xbbb", transactionHash: "0x2" }),
+          rawEvent({ fromAddress: "0xccc", transactionHash: "0x3" }),
+        ],
+      };
+    });
+
+    const page = await getEvents({
+      url: RPC_URL,
+      addresses: ["0xaaa", "0xbbb"],
+    });
+
+    expect(page.events.map((event) => event.transactionHash)).toEqual([
+      normalizeFelt("0x1"),
+      normalizeFelt("0x2"),
+    ]);
+    expect(requests).toHaveLength(1);
+    expect((requests[0] as JsonRpcRequest).params).toEqual([
+      {
+        chunk_size: 100,
+      },
+    ]);
+  });
+
   it("sends getBlockWithTxHashes block ids as positional JSON-RPC params", async () => {
     const requests: unknown[] = [];
     mockRpcFetch((request) => {

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { backfillEvents } from "../src/backfill";
-import { getBlockWithTxHashes } from "../src/block-cache";
+import { StarknetBlockCache, getBlockWithTxHashes } from "../src/block-cache";
 import { compareEventCursor, eventCursorKey } from "../src/cursor";
 import { getEvents } from "../src/http";
 import { normalizeEvent, normalizeFelt } from "../src/normalize";
@@ -37,13 +37,53 @@ describe("cursor comparison", () => {
     ).toBeGreaterThan(0);
     expect(
       compareEventCursor(cursor(2, "0x2", 1, 0), cursor(2, "0x1", 1, 0)),
-    ).toBeGreaterThan(0);
+    ).toBe(0);
   });
 
   it("keeps the cursor identity keyed by transaction hash and event index", () => {
     expect(eventCursorKey(cursor(5, "0xabc", 1, 2))).toBe(
       eventCursorKey(cursor(5, "0x0abc", 99, 2)),
     );
+  });
+});
+
+describe("block cache", () => {
+  it("caches blocks by number and hash and invalidates from a reorg start", async () => {
+    const requests: unknown[] = [];
+    mockRpcFetch((request) => {
+      requests.push(request);
+      return {
+        block_hash: "0xabc",
+        block_number: 10,
+        timestamp: 100,
+        transactions: [],
+      };
+    });
+
+    const cache = new StarknetBlockCache({ url: RPC_URL });
+
+    await expect(
+      cache.getBlockWithTxHashes({ block_number: 10 }),
+    ).resolves.toMatchObject({
+      block_number: 10,
+    });
+    await expect(
+      cache.getBlockWithTxHashes({ block_number: 10 }),
+    ).resolves.toMatchObject({
+      block_number: 10,
+    });
+    expect(requests).toHaveLength(1);
+    expect(
+      cache.getCachedMetadata({ block_hash: normalizeFelt("0xabc") }),
+    ).toMatchObject({
+      blockNumber: 10,
+      timestamp: 100,
+    });
+
+    cache.invalidateFrom(10);
+
+    await cache.getBlockWithTxHashes({ block_number: 10 });
+    expect(requests).toHaveLength(2);
   });
 });
 
@@ -452,6 +492,38 @@ describe("WebSocket subscriptions", () => {
 
     await expect(next).rejects.toBeInstanceOf(TooManyBlocksBackError);
     expect(socket.sent).toHaveLength(1);
+  });
+
+  it("rejects subscription-only block tags before sending", async () => {
+    const sockets: MockWebSocket[] = [];
+    const iterator = connectSubscribeEvents({
+      url: WS_URL,
+      blockId: "pending",
+      webSocketFactory: mockWebSocketFactory(sockets),
+    } as never);
+
+    const next = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+
+    await expect(next).rejects.toThrow(/blockId tag/);
+    expect(socket.sent).toHaveLength(0);
+  });
+
+  it("rejects unsupported subscription finality statuses before sending", async () => {
+    const sockets: MockWebSocket[] = [];
+    const iterator = connectSubscribeEvents({
+      url: WS_URL,
+      finalityStatus: "ACCEPTED_ON_L1",
+      webSocketFactory: mockWebSocketFactory(sockets),
+    } as never);
+
+    const next = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+
+    await expect(next).rejects.toThrow(/finalityStatus/);
+    expect(socket.sent).toHaveLength(0);
   });
 });
 

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -381,6 +381,12 @@ describe("WebSocket subscriptions", () => {
           endingBlockNumber: 13,
           endingBlockHash: normalizeFelt("0xdef"),
         },
+        rollbackCursor: {
+          blockNumber: 12,
+          transactionIndex: -1,
+          transactionHash: "0x0",
+          eventIndex: -1,
+        },
       },
     });
 
@@ -754,6 +760,92 @@ describe("combined stream", () => {
         chunk_size: 100,
       },
     ]);
+
+    await iterator.return?.(undefined);
+  });
+
+  it("rolls back a persisted pre-confirmed cursor ahead of accepted head before live resume", async () => {
+    const sockets: MockWebSocket[] = [];
+    const methods: string[] = [];
+
+    mockRpcFetch((request) => {
+      methods.push(request.method);
+
+      if (request.method === "starknet_getBlockWithTxHashes") {
+        return {
+          block_hash: "0x10",
+          block_number: 10,
+          timestamp: 110,
+          transactions: [],
+        };
+      }
+
+      if (request.method === "starknet_getEvents") {
+        throw new Error("streamEvents should not query an invalid HTTP range");
+      }
+
+      throw new Error(`unexpected method ${request.method}`);
+    });
+
+    const iterator = streamEvents({
+      url: RPC_URL,
+      wsUrl: WS_URL,
+      cursor: cursor(11, "0xaaa", 4, 2),
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "reorg",
+        reorg: {
+          startingBlockNumber: 11,
+          endingBlockNumber: 11,
+          synthetic: true,
+        },
+        rollbackCursor: {
+          blockNumber: 11,
+          transactionIndex: -1,
+          transactionHash: "0x0",
+          eventIndex: -1,
+        },
+      },
+    });
+    expect(methods).toEqual(["starknet_getBlockWithTxHashes"]);
+
+    const live = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+    const subscribe = await waitForSent(socket, "starknet_subscribeEvents");
+    expect((subscribe.params as { block_id: unknown }).block_id).toEqual({
+      block_number: 10,
+    });
+    socket.message({ jsonrpc: "2.0", id: 1, result: "sub-1" });
+    socket.message(
+      eventNotification(
+        "sub-1",
+        rawEvent({
+          blockNumber: 11,
+          transactionHash: "0xbbb",
+          transactionIndex: 4,
+          eventIndex: 2,
+          finalityStatus: "PRE_CONFIRMED",
+        }),
+      ),
+    );
+
+    await expect(live).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 11,
+          transactionIndex: 4,
+          transactionHash: normalizeFelt("0xbbb"),
+          eventIndex: 2,
+        },
+      },
+    });
 
     await iterator.return?.(undefined);
   });

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -3,12 +3,20 @@ import { backfillEvents } from "../src/backfill";
 import { StarknetBlockCache, getBlockWithTxHashes } from "../src/block-cache";
 import { compareEventCursor, eventCursorKey } from "../src/cursor";
 import { getEvents } from "../src/http";
-import { normalizeEvent, normalizeFelt } from "../src/normalize";
+import {
+  StarknetEventCursorError,
+  normalizeEvent,
+  normalizeFelt,
+} from "../src/normalize";
 import { streamEvents } from "../src/stream";
 import { StarknetRpcStream } from "../src/stream-config";
 import { subscribeEvents } from "../src/subscribe";
 import type { EventCursor, RpcEvent } from "../src/types";
-import { TooManyBlocksBackError, connectSubscribeEvents } from "../src/ws";
+import {
+  TooManyBlocksBackError,
+  WebSocketQueueOverflowError,
+  connectSubscribeEvents,
+} from "../src/ws";
 
 const RPC_URL = "http://example.test/rpc";
 const WS_URL = "ws://example.test/rpc";
@@ -102,6 +110,12 @@ describe("event normalization", () => {
 
     expect(() => normalizeEvent(missingTransactionIndex)).toThrow(
       /Starknet JSON-RPC >= 0\.10/,
+    );
+
+    const { block_number: _blockNumber, ...missingBlockNumber } = rawEvent();
+
+    expect(() => normalizeEvent(missingBlockNumber)).toThrow(
+      StarknetEventCursorError,
     );
   });
 });
@@ -559,6 +573,103 @@ describe("WebSocket subscriptions", () => {
     await iterator.return?.(undefined);
   });
 
+  it("drops malformed WebSocket frames without reconnecting", async () => {
+    const sockets: MockWebSocket[] = [];
+    const iterator = connectSubscribeEvents({
+      url: WS_URL,
+      idleTimeoutMs: 0,
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+
+    const next = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+    await waitForSent(socket, "starknet_subscribeEvents");
+    socket.rawMessage("not-json");
+    socket.message({ jsonrpc: "2.0", id: 1, result: "sub-1" });
+    socket.rawMessage("{");
+    socket.message(eventNotification("sub-1", rawEvent({ blockNumber: 1 })));
+
+    await expect(next).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 1,
+        },
+      },
+    });
+    expect(sockets).toHaveLength(1);
+
+    await iterator.return?.(undefined);
+  });
+
+  it("surfaces queue overflow instead of buffering without bound", async () => {
+    const sockets: MockWebSocket[] = [];
+    const iterator = connectSubscribeEvents({
+      url: WS_URL,
+      idleTimeoutMs: 0,
+      maxQueueSize: 1,
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+
+    const first = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+    await waitForSent(socket, "starknet_subscribeEvents");
+    socket.message({ jsonrpc: "2.0", id: 1, result: "sub-1" });
+    socket.message(eventNotification("sub-1", rawEvent({ blockNumber: 1 })));
+
+    await expect(first).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 1,
+        },
+      },
+    });
+
+    socket.message(
+      eventNotification(
+        "sub-1",
+        rawEvent({ blockNumber: 2, transactionHash: "0x2" }),
+      ),
+    );
+    await flushTasks();
+    socket.message(
+      eventNotification(
+        "sub-1",
+        rawEvent({ blockNumber: 3, transactionHash: "0x3" }),
+      ),
+    );
+    socket.message(
+      eventNotification(
+        "sub-1",
+        rawEvent({ blockNumber: 4, transactionHash: "0x4" }),
+      ),
+    );
+    socket.message(
+      eventNotification(
+        "sub-1",
+        rawEvent({ blockNumber: 5, transactionHash: "0x5" }),
+      ),
+    );
+    await flushTasks();
+
+    let overflow: unknown;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      try {
+        await iterator.next();
+      } catch (error) {
+        overflow = error;
+        break;
+      }
+    }
+
+    expect(overflow).toBeInstanceOf(WebSocketQueueOverflowError);
+  });
+
   it("dedupes replayed events after reconnect", async () => {
     const sockets: MockWebSocket[] = [];
     const subscription = subscribeEvents({
@@ -609,6 +720,68 @@ describe("WebSocket subscriptions", () => {
         },
       },
     });
+
+    await subscription.unsubscribe();
+  });
+
+  it("reconnects after the WebSocket idle timeout", async () => {
+    const sockets: MockWebSocket[] = [];
+    const subscription = subscribeEvents({
+      url: WS_URL,
+      blockId: { block_number: 1 },
+      idleTimeoutMs: 1,
+      reconnect: { minDelayMs: 0, maxDelayMs: 0 },
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+    const iterator = subscription[Symbol.asyncIterator]();
+
+    const next = iterator.next();
+    const socket1 = await waitForSocket(sockets, 0);
+    socket1.open();
+    await waitForSent(socket1, "starknet_subscribeEvents");
+    socket1.message({ jsonrpc: "2.0", id: 1, result: "sub-1" });
+
+    const socket2 = await waitForSocket(sockets, 1);
+    socket2.open();
+    await waitForSent(socket2, "starknet_subscribeEvents");
+    socket2.message({ jsonrpc: "2.0", id: 1, result: "sub-2" });
+    socket2.message(
+      eventNotification(
+        "sub-2",
+        rawEvent({ blockNumber: 1, transactionHash: "0x1" }),
+      ),
+    );
+
+    await expect(next).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 1,
+        },
+      },
+    });
+
+    await subscription.unsubscribe();
+  });
+
+  it("honors a reconnect attempt ceiling", async () => {
+    const sockets: MockWebSocket[] = [];
+    const subscription = subscribeEvents({
+      url: WS_URL,
+      reconnect: { minDelayMs: 0, maxDelayMs: 0, maxAttempts: 0 },
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+    const iterator = subscription[Symbol.asyncIterator]();
+
+    const next = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+    await waitForSent(socket, "starknet_subscribeEvents");
+    socket.close();
+
+    await expect(next).rejects.toThrow(/reconnect attempts exceeded 0/);
+    expect(sockets).toHaveLength(1);
 
     await subscription.unsubscribe();
   });
@@ -750,11 +923,9 @@ describe("WebSocket subscriptions", () => {
     } as never);
 
     const next = iterator.next();
-    const socket = await waitForSocket(sockets, 0);
-    socket.open();
 
     await expect(next).rejects.toThrow(/blockId tag/);
-    expect(socket.sent).toHaveLength(0);
+    expect(sockets).toHaveLength(0);
   });
 
   it("rejects unsupported subscription finality statuses before sending", async () => {
@@ -766,11 +937,9 @@ describe("WebSocket subscriptions", () => {
     } as never);
 
     const next = iterator.next();
-    const socket = await waitForSocket(sockets, 0);
-    socket.open();
 
     await expect(next).rejects.toThrow(/finalityStatus/);
-    expect(socket.sent).toHaveLength(0);
+    expect(sockets).toHaveLength(0);
   });
 });
 
@@ -1025,6 +1194,107 @@ describe("combined stream", () => {
       },
       {
         from_block: { block_number: 10 },
+        to_block: { block_number: 12 },
+        chunk_size: 100,
+      },
+    ]);
+
+    await iterator.return?.(undefined);
+  });
+
+  it("skips invalid HTTP ranges when a reorg leaves accepted head before the reorg start", async () => {
+    const sockets: MockWebSocket[] = [];
+    const eventRequests: Array<Record<string, unknown>> = [];
+    let latestCalls = 0;
+
+    mockRpcFetch((request) => {
+      if (request.method === "starknet_getBlockWithTxHashes") {
+        latestCalls += 1;
+        const blockNumber = latestCalls === 1 ? 12 : 10;
+        return {
+          block_hash: `0x${blockNumber.toString(16)}`,
+          block_number: blockNumber,
+          timestamp: 100 + blockNumber,
+          transactions: [],
+        };
+      }
+
+      if (request.method === "starknet_getEvents") {
+        const filter = singleParam(request);
+        eventRequests.push(filter);
+
+        if (
+          isBlockNumberParam(filter.from_block) &&
+          isBlockNumberParam(filter.to_block) &&
+          filter.from_block.block_number > filter.to_block.block_number
+        ) {
+          throw new Error("streamEvents should not query an invalid range");
+        }
+
+        return { events: [] };
+      }
+
+      throw new Error(`unexpected method ${request.method}`);
+    });
+
+    const iterator = streamEvents({
+      url: RPC_URL,
+      wsUrl: WS_URL,
+      fromBlock: { block_number: 0 },
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+
+    const reorg = iterator.next();
+    const socket1 = await waitForSocket(sockets, 0);
+    socket1.open();
+    await waitForSent(socket1, "starknet_subscribeEvents");
+    socket1.message({ jsonrpc: "2.0", id: 1, result: "sub-1" });
+    socket1.message(
+      reorgNotification("sub-1", {
+        starting_block_number: 12,
+        starting_block_hash: "0x12",
+        ending_block_number: 12,
+        ending_block_hash: "0x12",
+      }),
+    );
+
+    await expect(reorg).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "reorg",
+        reorg: {
+          startingBlockNumber: 12,
+        },
+      },
+    });
+
+    const live = iterator.next();
+    const socket2 = await waitForSocket(sockets, 1);
+    socket2.open();
+    const subscribe = await waitForSent(socket2, "starknet_subscribeEvents");
+    expect((subscribe.params as { block_id: unknown }).block_id).toEqual({
+      block_number: 10,
+    });
+    socket2.message({ jsonrpc: "2.0", id: 1, result: "sub-2" });
+    socket2.message(
+      eventNotification(
+        "sub-2",
+        rawEvent({ blockNumber: 12, transactionHash: "0x12" }),
+      ),
+    );
+
+    await expect(live).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 12,
+        },
+      },
+    });
+    expect(eventRequests).toEqual([
+      {
+        from_block: { block_number: 0 },
         to_block: { block_number: 12 },
         chunk_size: 100,
       },
@@ -1426,6 +1696,25 @@ function eventNotification(subscriptionId: string, event: RpcEvent) {
   };
 }
 
+function reorgNotification(
+  subscriptionId: string,
+  reorg: {
+    starting_block_number: number;
+    starting_block_hash: string;
+    ending_block_number: number;
+    ending_block_hash: string;
+  },
+) {
+  return {
+    jsonrpc: "2.0",
+    method: "starknet_subscriptionReorg",
+    params: {
+      subscription_id: subscriptionId,
+      result: reorg,
+    },
+  };
+}
+
 function mockRpcFetch(
   handler: (request: JsonRpcRequest) => unknown | Promise<unknown>,
 ): void {
@@ -1518,6 +1807,10 @@ class MockWebSocket {
     this.dispatch("message", { data: JSON.stringify(value) });
   }
 
+  rawMessage(data: unknown): void {
+    this.dispatch("message", { data });
+  }
+
   private dispatch(type: string, event: unknown): void {
     for (const listener of this.#listeners.get(type) ?? []) {
       listener(event);
@@ -1556,4 +1849,8 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
   }
+}
+
+async function flushTasks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -429,6 +429,16 @@ describe("WebSocket subscriptions", () => {
 });
 
 describe("combined stream", () => {
+  it("rejects bounded toBlock options", async () => {
+    const iterator = streamEvents({
+      url: RPC_URL,
+      wsUrl: WS_URL,
+      toBlock: { block_number: 10 },
+    } as never);
+
+    await expect(iterator.next()).rejects.toThrow(/toBlock/);
+  });
+
   it("dedupes the inclusive HTTP-to-WS handoff", async () => {
     const sockets: MockWebSocket[] = [];
     mockRpcFetch((request) => {
@@ -503,6 +513,90 @@ describe("combined stream", () => {
 
     await iterator.return?.(undefined);
   });
+
+  it("catches up over HTTP when the WS handoff block is too old", async () => {
+    const sockets: MockWebSocket[] = [];
+    const eventRequests: Array<Record<string, unknown>> = [];
+    let latestCalls = 0;
+
+    mockRpcFetch((request) => {
+      if (request.method === "starknet_getBlockWithTxHashes") {
+        latestCalls += 1;
+        const blockNumber = latestCalls === 1 ? 10 : 12;
+        return {
+          block_hash: `0x${blockNumber.toString(16)}`,
+          block_number: blockNumber,
+          timestamp: 100 + blockNumber,
+          transactions: [],
+        };
+      }
+
+      if (request.method === "starknet_getEvents") {
+        const filter = singleParam(request);
+        eventRequests.push(filter);
+
+        if (
+          isBlockNumberParam(filter.to_block) &&
+          filter.to_block.block_number === 12
+        ) {
+          return {
+            events: [rawEvent({ blockNumber: 11, transactionHash: "0x11" })],
+          };
+        }
+
+        return { events: [] };
+      }
+
+      throw new Error(`unexpected method ${request.method}`);
+    });
+
+    const iterator = streamEvents({
+      url: RPC_URL,
+      wsUrl: WS_URL,
+      fromBlock: { block_number: 0 },
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+
+    const next = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+    const subscribe = await waitForSent(socket, "starknet_subscribeEvents");
+    expect((subscribe.params as { block_id: unknown }).block_id).toEqual({
+      block_number: 10,
+    });
+    socket.message({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: 68,
+        message: "Cannot go back more than 1024 blocks",
+      },
+    });
+
+    await expect(next).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 11,
+        },
+      },
+    });
+    expect(eventRequests).toEqual([
+      {
+        from_block: { block_number: 0 },
+        to_block: { block_number: 10 },
+        chunk_size: 100,
+      },
+      {
+        from_block: { block_number: 10 },
+        to_block: { block_number: 12 },
+        chunk_size: 100,
+      },
+    ]);
+
+    await iterator.return?.(undefined);
+  });
 });
 
 type JsonRpcRequest = {
@@ -522,6 +616,10 @@ function singleParam(request: JsonRpcRequest): Record<string, unknown> {
   }
 
   return param as Record<string, unknown>;
+}
+
+function isBlockNumberParam(value: unknown): value is { block_number: number } {
+  return typeof value === "object" && value !== null && "block_number" in value;
 }
 
 function cursor(

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { backfillEvents } from "./backfill";
-import { getBlockWithTxHashes } from "./block-cache";
-import { compareEventCursor, eventCursorKey } from "./cursor";
-import { getEvents } from "./http";
-import { normalizeEvent, normalizeFelt } from "./normalize";
-import { streamEvents } from "./stream";
-import { subscribeEvents } from "./subscribe";
-import type { EventCursor, RpcEvent } from "./types";
-import { TooManyBlocksBackError, connectSubscribeEvents } from "./ws";
+import { backfillEvents } from "../src/backfill";
+import { getBlockWithTxHashes } from "../src/block-cache";
+import { compareEventCursor, eventCursorKey } from "../src/cursor";
+import { getEvents } from "../src/http";
+import { normalizeEvent, normalizeFelt } from "../src/normalize";
+import { streamEvents } from "../src/stream";
+import { subscribeEvents } from "../src/subscribe";
+import type { EventCursor, RpcEvent } from "../src/types";
+import { TooManyBlocksBackError, connectSubscribeEvents } from "../src/ws";
 
 const RPC_URL = "http://example.test/rpc";
 const WS_URL = "ws://example.test/rpc";

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -240,6 +240,41 @@ describe("HTTP backfill", () => {
 });
 
 describe("WebSocket subscriptions", () => {
+  it("subscribes to pre-confirmed events by default", async () => {
+    const sockets: MockWebSocket[] = [];
+    const subscription = subscribeEvents({
+      url: WS_URL,
+      blockId: "latest",
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+    const iterator = subscription[Symbol.asyncIterator]();
+
+    const next = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+    const subscribe = await waitForSent(socket, "starknet_subscribeEvents");
+    expect(
+      (subscribe.params as { finality_status: unknown }).finality_status,
+    ).toBe("PRE_CONFIRMED");
+
+    socket.message({ jsonrpc: "2.0", id: 1, result: "sub-1" });
+    socket.message(
+      eventNotification("sub-1", rawEvent({ finalityStatus: "PRE_CONFIRMED" })),
+    );
+
+    await expect(next).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        event: {
+          finalityStatus: "PRE_CONFIRMED",
+        },
+      },
+    });
+
+    await subscription.unsubscribe();
+  });
+
   it("emits Pathfinder reorg notifications", async () => {
     const sockets: MockWebSocket[] = [];
     const iterator = connectSubscribeEvents({
@@ -409,6 +444,9 @@ describe("combined stream", () => {
     expect((subscribe.params as { block_id: unknown }).block_id).toEqual({
       block_number: 10,
     });
+    expect(
+      (subscribe.params as { finality_status: unknown }).finality_status,
+    ).toBe("PRE_CONFIRMED");
     socket.message({ jsonrpc: "2.0", id: 1, result: "sub-1" });
     socket.message(
       eventNotification(
@@ -474,6 +512,7 @@ function rawEvent({
   fromAddress = "0xaaa",
   keys = ["0x111"],
   data = ["0x222"],
+  finalityStatus = "ACCEPTED_ON_L2",
 }: {
   blockNumber?: number;
   blockHash?: string;
@@ -483,6 +522,7 @@ function rawEvent({
   fromAddress?: string;
   keys?: string[];
   data?: string[];
+  finalityStatus?: RpcEvent["finality_status"];
 } = {}): RpcEvent {
   return {
     block_number: blockNumber,
@@ -493,7 +533,7 @@ function rawEvent({
     from_address: fromAddress,
     keys,
     data,
-    finality_status: "ACCEPTED_ON_L2",
+    finality_status: finalityStatus,
   };
 }
 

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -347,6 +347,33 @@ describe("WebSocket subscriptions", () => {
     await iterator.return?.(undefined);
   });
 
+  it("buffers notifications that arrive before the subscription response", async () => {
+    const sockets: MockWebSocket[] = [];
+    const iterator = connectSubscribeEvents({
+      url: WS_URL,
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+
+    const next = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+    await waitForSent(socket, "starknet_subscribeEvents");
+    socket.message(eventNotification("sub-1", rawEvent({ blockNumber: 1 })));
+    socket.message({ jsonrpc: "2.0", id: 1, result: "sub-1" });
+
+    await expect(next).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 1,
+        },
+      },
+    });
+
+    await iterator.return?.(undefined);
+  });
+
   it("dedupes replayed events after reconnect", async () => {
     const sockets: MockWebSocket[] = [];
     const subscription = subscribeEvents({

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -5,6 +5,7 @@ import { compareEventCursor, eventCursorKey } from "../src/cursor";
 import { getEvents } from "../src/http";
 import { normalizeEvent, normalizeFelt } from "../src/normalize";
 import { streamEvents } from "../src/stream";
+import { StarknetRpcStream } from "../src/stream-config";
 import { subscribeEvents } from "../src/subscribe";
 import type { EventCursor, RpcEvent } from "../src/types";
 import { TooManyBlocksBackError, connectSubscribeEvents } from "../src/ws";
@@ -310,6 +311,143 @@ describe("HTTP backfill", () => {
   });
 });
 
+describe("RPC stream config", () => {
+  it("fetches accepted event blocks for the Apibara RPC client path", async () => {
+    const requests: JsonRpcRequest[] = [];
+    mockRpcFetch((request) => {
+      requests.push(request);
+
+      if (request.method === "starknet_getEvents") {
+        return {
+          events: [
+            rawEvent({ blockNumber: 1, transactionHash: "0x1" }),
+            rawEvent({
+              blockNumber: 2,
+              transactionHash: "0x2",
+              transactionIndex: 1,
+            }),
+          ],
+        };
+      }
+
+      if (request.method === "starknet_getBlockWithTxHashes") {
+        const blockId = request.params?.[0];
+        const blockNumber = isBlockNumberParam(blockId)
+          ? blockId.block_number
+          : 0;
+        return rpcBlock(blockNumber);
+      }
+
+      throw new Error(`unexpected method ${request.method}`);
+    });
+
+    const stream = new StarknetRpcStream({ url: RPC_URL });
+    const result = await stream.fetchBlockRange({
+      startBlock: 1n,
+      maxBlock: 2n,
+      force: false,
+      clampAllowed: false,
+      filter: {},
+    });
+
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0]).toMatchObject({
+      endCursor: {
+        orderKey: 1n,
+        uniqueKey: normalizeFelt("0x1"),
+      },
+      block: {
+        header: {
+          blockNumber: 1,
+          blockHash: normalizeFelt("0x1"),
+          parentBlockHash: normalizeFelt("0x0"),
+        },
+        events: [
+          {
+            transactionHash: normalizeFelt("0x1"),
+          },
+        ],
+      },
+    });
+    expect(result.data[1]).toMatchObject({
+      endCursor: {
+        orderKey: 2n,
+        uniqueKey: normalizeFelt("0x2"),
+      },
+      block: {
+        events: [
+          {
+            transactionHash: normalizeFelt("0x2"),
+          },
+        ],
+      },
+    });
+    expect(
+      requests.filter((request) => request.method === "starknet_getEvents"),
+    ).toHaveLength(1);
+  });
+
+  it("maps finalized cursor requests to l1_accepted", async () => {
+    const requests: JsonRpcRequest[] = [];
+    mockRpcFetch((request) => {
+      requests.push(request);
+      return rpcBlock(10);
+    });
+
+    const stream = new StarknetRpcStream({ url: RPC_URL });
+    await expect(
+      stream.fetchCursor({ blockTag: "finalized" }),
+    ).resolves.toEqual({
+      blockNumber: 10n,
+      blockHash: normalizeFelt("0xa"),
+      parentBlockHash: normalizeFelt("0x9"),
+    });
+    expect(requests[0].params).toEqual(["l1_accepted"]);
+  });
+
+  it("clamps accepted event backfill ranges when allowed", async () => {
+    const requests: JsonRpcRequest[] = [];
+    mockRpcFetch((request) => {
+      requests.push(request);
+
+      if (request.method === "starknet_getEvents") {
+        return { events: [] };
+      }
+
+      if (request.method === "starknet_getBlockWithTxHashes") {
+        const blockId = request.params?.[0];
+        const blockNumber = isBlockNumberParam(blockId)
+          ? blockId.block_number
+          : 0;
+        return rpcBlock(blockNumber);
+      }
+
+      throw new Error(`unexpected method ${request.method}`);
+    });
+
+    const stream = new StarknetRpcStream({
+      url: RPC_URL,
+      getEventsRangeSize: 3n,
+    });
+    const result = await stream.fetchBlockRange({
+      startBlock: 1n,
+      maxBlock: 10n,
+      force: true,
+      clampAllowed: true,
+      filter: {},
+    });
+
+    expect(result.endBlock).toBe(3n);
+    const getEventsRequest = requests.find(
+      (request) => request.method === "starknet_getEvents",
+    );
+    expect(getEventsRequest).toBeDefined();
+    expect(singleParam(getEventsRequest!).to_block).toEqual({
+      block_number: 3,
+    });
+  });
+});
+
 describe("WebSocket subscriptions", () => {
   it("subscribes to pre-confirmed events by default", async () => {
     const sockets: MockWebSocket[] = [];
@@ -475,6 +613,108 @@ describe("WebSocket subscriptions", () => {
     await subscription.unsubscribe();
   });
 
+  it("emits repeated event identities when finality changes", async () => {
+    const sockets: MockWebSocket[] = [];
+    const subscription = subscribeEvents({
+      url: WS_URL,
+      blockId: { block_number: 1 },
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+    const iterator = subscription[Symbol.asyncIterator]();
+
+    const first = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+    await waitForSent(socket, "starknet_subscribeEvents");
+    socket.message({ jsonrpc: "2.0", id: 1, result: "sub-1" });
+    socket.message(
+      eventNotification(
+        "sub-1",
+        rawEvent({
+          blockNumber: 1,
+          blockHash: undefined,
+          transactionHash: "0x1",
+          finalityStatus: "PRE_CONFIRMED",
+        }),
+      ),
+    );
+
+    await expect(first).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 1,
+          transactionHash: normalizeFelt("0x1"),
+        },
+        event: {
+          blockHash: undefined,
+          finalityStatus: "PRE_CONFIRMED",
+        },
+      },
+    });
+
+    const accepted = iterator.next();
+    socket.message(
+      eventNotification(
+        "sub-1",
+        rawEvent({
+          blockNumber: 1,
+          blockHash: "0xabc",
+          transactionHash: "0x1",
+          finalityStatus: "ACCEPTED_ON_L2",
+        }),
+      ),
+    );
+
+    await expect(accepted).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 1,
+          transactionHash: normalizeFelt("0x1"),
+        },
+        event: {
+          blockHash: normalizeFelt("0xabc"),
+          finalityStatus: "ACCEPTED_ON_L2",
+        },
+      },
+    });
+
+    const next = iterator.next();
+    socket.message(
+      eventNotification(
+        "sub-1",
+        rawEvent({
+          blockNumber: 1,
+          blockHash: "0xabc",
+          transactionHash: "0x1",
+          finalityStatus: "ACCEPTED_ON_L2",
+        }),
+      ),
+    );
+    socket.message(
+      eventNotification(
+        "sub-1",
+        rawEvent({ blockNumber: 2, transactionHash: "0x2" }),
+      ),
+    );
+
+    await expect(next).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 2,
+          transactionHash: normalizeFelt("0x2"),
+        },
+      },
+    });
+
+    await subscription.unsubscribe();
+  });
+
   it("surfaces TooManyBlocksBack without trying historical WS backfill", async () => {
     const sockets: MockWebSocket[] = [];
     const iterator = connectSubscribeEvents({
@@ -613,6 +853,95 @@ describe("combined stream", () => {
         type: "event",
         cursor: {
           blockNumber: 11,
+        },
+      },
+    });
+
+    await iterator.return?.(undefined);
+  });
+
+  it("emits live finality updates for the same event identity", async () => {
+    const sockets: MockWebSocket[] = [];
+    mockRpcFetch((request) => {
+      if (request.method === "starknet_getBlockWithTxHashes") {
+        return {
+          block_hash: "0x123",
+          block_number: 10,
+          timestamp: 100,
+          transactions: [],
+        };
+      }
+
+      if (request.method === "starknet_getEvents") {
+        return { events: [] };
+      }
+
+      throw new Error(`unexpected method ${request.method}`);
+    });
+
+    const iterator = streamEvents({
+      url: RPC_URL,
+      wsUrl: WS_URL,
+      fromBlock: { block_number: 10 },
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+
+    const first = iterator.next();
+    const socket = await waitForSocket(sockets, 0);
+    socket.open();
+    await waitForSent(socket, "starknet_subscribeEvents");
+    socket.message({ jsonrpc: "2.0", id: 1, result: "sub-1" });
+    socket.message(
+      eventNotification(
+        "sub-1",
+        rawEvent({
+          blockNumber: 11,
+          blockHash: undefined,
+          transactionHash: "0x11",
+          finalityStatus: "PRE_CONFIRMED",
+        }),
+      ),
+    );
+
+    await expect(first).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 11,
+          transactionHash: normalizeFelt("0x11"),
+        },
+        event: {
+          blockHash: undefined,
+          finalityStatus: "PRE_CONFIRMED",
+        },
+      },
+    });
+
+    const accepted = iterator.next();
+    socket.message(
+      eventNotification(
+        "sub-1",
+        rawEvent({
+          blockNumber: 11,
+          blockHash: "0xabc",
+          transactionHash: "0x11",
+          finalityStatus: "ACCEPTED_ON_L2",
+        }),
+      ),
+    );
+
+    await expect(accepted).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 11,
+          transactionHash: normalizeFelt("0x11"),
+        },
+        event: {
+          blockHash: normalizeFelt("0xabc"),
+          finalityStatus: "ACCEPTED_ON_L2",
         },
       },
     });
@@ -1006,7 +1335,7 @@ describe("combined stream", () => {
 
 type JsonRpcRequest = {
   method: string;
-  params: unknown;
+  params?: unknown[];
 };
 
 function singleParam(request: JsonRpcRequest): Record<string, unknown> {
@@ -1027,6 +1356,17 @@ function isBlockNumberParam(value: unknown): value is { block_number: number } {
   return typeof value === "object" && value !== null && "block_number" in value;
 }
 
+function rpcBlock(blockNumber: number) {
+  const parentBlockNumber = Math.max(0, blockNumber - 1);
+  return {
+    block_hash: `0x${blockNumber.toString(16)}`,
+    parent_hash: `0x${parentBlockNumber.toString(16)}`,
+    block_number: blockNumber,
+    timestamp: 100 + blockNumber,
+    transactions: [],
+  };
+}
+
 function cursor(
   blockNumber: number,
   transactionHash = "0x1",
@@ -1038,7 +1378,7 @@ function cursor(
 
 function rawEvent({
   blockNumber = 1,
-  blockHash = "0xabc",
+  blockHash,
   transactionHash = "0x1",
   transactionIndex = 0,
   eventIndex = 0,
@@ -1057,9 +1397,8 @@ function rawEvent({
   data?: string[];
   finalityStatus?: RpcEvent["finality_status"];
 } = {}): RpcEvent {
-  return {
+  const event: RpcEvent = {
     block_number: blockNumber,
-    block_hash: blockHash,
     transaction_hash: transactionHash,
     transaction_index: transactionIndex,
     event_index: eventIndex,
@@ -1068,6 +1407,12 @@ function rawEvent({
     data,
     finality_status: finalityStatus,
   };
+
+  if (blockHash !== undefined) {
+    event.block_hash = blockHash;
+  }
+
+  return event;
 }
 
 function eventNotification(subscriptionId: string, event: RpcEvent) {

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -210,6 +210,30 @@ describe("HTTP backfill", () => {
     ]);
   });
 
+  it("defaults omitted backfill toBlock to latest accepted block", async () => {
+    const requests: unknown[] = [];
+    mockRpcFetch((request) => {
+      requests.push(request);
+      return { events: [] };
+    });
+
+    await collect(
+      backfillEvents({
+        url: RPC_URL,
+        fromBlock: { block_number: 1 },
+      }),
+    );
+
+    expect(requests).toHaveLength(1);
+    expect((requests[0] as JsonRpcRequest).params).toEqual([
+      {
+        from_block: { block_number: 1 },
+        to_block: "latest",
+        chunk_size: 100,
+      },
+    ]);
+  });
+
   it("sends v0.10 multi-address RPC filters and filters client-side", async () => {
     const requests: unknown[] = [];
     mockRpcFetch((request) => {
@@ -316,6 +340,7 @@ describe("HTTP backfill", () => {
     expect((requests[0] as JsonRpcRequest).params).toEqual([
       {
         from_block: { block_number: 5 },
+        to_block: "latest",
         chunk_size: 100,
       },
     ]);

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -60,7 +60,7 @@ describe("event normalization", () => {
       rawEvent();
 
     expect(() => normalizeEvent(missingTransactionIndex)).toThrow(
-      /event\.transaction_index/,
+      /Starknet JSON-RPC >= 0\.10/,
     );
   });
 });

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -696,6 +696,67 @@ describe("combined stream", () => {
 
     await iterator.return?.(undefined);
   });
+
+  it("retries HTTP transport errors and resumes backfill", async () => {
+    const sockets: MockWebSocket[] = [];
+    const eventRequests: Array<Record<string, unknown>> = [];
+    let latestCalls = 0;
+
+    vi.spyOn(Math, "random").mockReturnValue(-1);
+    mockRpcFetch(async (request) => {
+      if (request.method === "starknet_getBlockWithTxHashes") {
+        latestCalls += 1;
+
+        if (latestCalls === 1) {
+          return new Response("temporary unavailable", { status: 503 });
+        }
+
+        return {
+          block_hash: "0x14",
+          block_number: 20,
+          timestamp: 120,
+          transactions: [],
+        };
+      }
+
+      if (request.method === "starknet_getEvents") {
+        const filter = singleParam(request);
+        eventRequests.push(filter);
+        return {
+          events: [rawEvent({ blockNumber: 20, transactionHash: "0x20" })],
+        };
+      }
+
+      throw new Error(`unexpected method ${request.method}`);
+    });
+
+    const iterator = streamEvents({
+      url: RPC_URL,
+      wsUrl: WS_URL,
+      fromBlock: { block_number: 0 },
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 20,
+        },
+      },
+    });
+    expect(latestCalls).toBe(2);
+    expect(eventRequests).toEqual([
+      {
+        from_block: { block_number: 0 },
+        to_block: { block_number: 20 },
+        chunk_size: 100,
+      },
+    ]);
+
+    await iterator.return?.(undefined);
+  });
 });
 
 type JsonRpcRequest = {
@@ -775,14 +836,20 @@ function eventNotification(subscriptionId: string, event: RpcEvent) {
   };
 }
 
-function mockRpcFetch(handler: (request: JsonRpcRequest) => unknown): void {
+function mockRpcFetch(
+  handler: (request: JsonRpcRequest) => unknown | Promise<unknown>,
+): void {
   vi.stubGlobal(
     "fetch",
     vi.fn(async (_url: string, init?: RequestInit) => {
       const request = JSON.parse(String(init?.body)) as JsonRpcRequest & {
         id?: number | string;
       };
-      const result = handler(request);
+      const result = await handler(request);
+
+      if (result instanceof Response) {
+        return result;
+      }
 
       return new Response(
         JSON.stringify({

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -195,7 +195,7 @@ describe("HTTP backfill", () => {
     ]);
   });
 
-  it("omits non-conformant multi-address RPC filters and filters client-side", async () => {
+  it("sends v0.10 multi-address RPC filters and filters client-side", async () => {
     const requests: unknown[] = [];
     mockRpcFetch((request) => {
       requests.push(request);
@@ -220,6 +220,7 @@ describe("HTTP backfill", () => {
     expect(requests).toHaveLength(1);
     expect((requests[0] as JsonRpcRequest).params).toEqual([
       {
+        address: [normalizeFelt("0xaaa"), normalizeFelt("0xbbb")],
         chunk_size: 100,
       },
     ]);
@@ -846,6 +847,158 @@ describe("combined stream", () => {
         },
       },
     });
+
+    await iterator.return?.(undefined);
+  });
+
+  it("replays a persisted pre-confirmed cursor block after accepted head catches up", async () => {
+    const sockets: MockWebSocket[] = [];
+    const eventRequests: Array<Record<string, unknown>> = [];
+
+    mockRpcFetch((request) => {
+      if (request.method === "starknet_getBlockWithTxHashes") {
+        return {
+          block_hash: "0x0b",
+          block_number: 11,
+          timestamp: 111,
+          transactions: [],
+        };
+      }
+
+      if (request.method === "starknet_getEvents") {
+        const filter = singleParam(request);
+        eventRequests.push(filter);
+        return {
+          events: [
+            rawEvent({
+              blockNumber: 11,
+              transactionHash: "0xbbb",
+              transactionIndex: 4,
+              eventIndex: 2,
+              finalityStatus: "ACCEPTED_ON_L2",
+            }),
+          ],
+        };
+      }
+
+      throw new Error(`unexpected method ${request.method}`);
+    });
+
+    const iterator = streamEvents({
+      url: RPC_URL,
+      wsUrl: WS_URL,
+      cursor: cursor(11, "0xaaa", 4, 2),
+      cursorFinalityStatus: "PRE_CONFIRMED",
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "reorg",
+        reorg: {
+          startingBlockNumber: 11,
+          endingBlockNumber: 11,
+          synthetic: true,
+        },
+        rollbackCursor: {
+          blockNumber: 11,
+          transactionIndex: -1,
+          transactionHash: "0x0",
+          eventIndex: -1,
+        },
+      },
+    });
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 11,
+          transactionIndex: 4,
+          transactionHash: normalizeFelt("0xbbb"),
+          eventIndex: 2,
+        },
+      },
+    });
+    expect(eventRequests).toEqual([
+      {
+        from_block: { block_number: 11 },
+        to_block: { block_number: 11 },
+        chunk_size: 100,
+      },
+    ]);
+    expect(sockets).toHaveLength(0);
+
+    await iterator.return?.(undefined);
+  });
+
+  it("skips conservative cursor-block replay when the persisted cursor is accepted", async () => {
+    const sockets: MockWebSocket[] = [];
+    const eventRequests: Array<Record<string, unknown>> = [];
+
+    mockRpcFetch((request) => {
+      if (request.method === "starknet_getBlockWithTxHashes") {
+        return {
+          block_hash: "0x0b",
+          block_number: 11,
+          timestamp: 111,
+          transactions: [],
+        };
+      }
+
+      if (request.method === "starknet_getEvents") {
+        const filter = singleParam(request);
+        eventRequests.push(filter);
+        return {
+          events: [
+            rawEvent({
+              blockNumber: 11,
+              transactionHash: "0xaaa",
+              transactionIndex: 4,
+              eventIndex: 2,
+            }),
+            rawEvent({
+              blockNumber: 11,
+              transactionHash: "0xccc",
+              transactionIndex: 5,
+              eventIndex: 0,
+            }),
+          ],
+        };
+      }
+
+      throw new Error(`unexpected method ${request.method}`);
+    });
+
+    const iterator = streamEvents({
+      url: RPC_URL,
+      wsUrl: WS_URL,
+      cursor: cursor(11, "0xaaa", 4, 2),
+      cursorFinalityStatus: "ACCEPTED_ON_L2",
+      webSocketFactory: mockWebSocketFactory(sockets),
+    });
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "event",
+        cursor: {
+          blockNumber: 11,
+          transactionIndex: 5,
+          transactionHash: normalizeFelt("0xccc"),
+          eventIndex: 0,
+        },
+      },
+    });
+    expect(eventRequests).toEqual([
+      {
+        from_block: { block_number: 11 },
+        to_block: { block_number: 11 },
+        chunk_size: 100,
+      },
+    ]);
 
     await iterator.return?.(undefined);
   });

--- a/packages/starknet-rpc/tests/starknet-rpc.test.ts
+++ b/packages/starknet-rpc/tests/starknet-rpc.test.ts
@@ -210,6 +210,51 @@ describe("HTTP backfill", () => {
     ]);
   });
 
+  it("does not accumulate fetch abort listeners on a reused parent signal", async () => {
+    const controller = new AbortController();
+    const addListener = vi.spyOn(controller.signal, "addEventListener");
+    const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+    const fetchSignals: Array<AbortSignal | null | undefined> = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        fetchSignals.push(init?.signal);
+        const request = JSON.parse(String(init?.body)) as JsonRpcRequest & {
+          id?: number | string;
+        };
+
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: request.id ?? 1,
+            result: { events: [] },
+          }),
+          {
+            headers: {
+              "content-type": "application/json",
+            },
+          },
+        );
+      }),
+    );
+
+    for (let i = 0; i < 3; i++) {
+      await getEvents({
+        url: RPC_URL,
+        fromBlock: { block_number: i },
+        signal: controller.signal,
+      });
+    }
+
+    expect(addListener).toHaveBeenCalledTimes(3);
+    expect(removeListener).toHaveBeenCalledTimes(3);
+    expect(fetchSignals).toHaveLength(3);
+    expect(fetchSignals.every((signal) => signal !== controller.signal)).toBe(
+      true,
+    );
+  });
+
   it("defaults omitted backfill toBlock to latest accepted block", async () => {
     const requests: unknown[] = [];
     mockRpcFetch((request) => {

--- a/packages/starknet-rpc/tsconfig.json
+++ b/packages/starknet-rpc/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declarationDir": "dist",
+    "noEmit": false,
+    "rootDir": ".",
+    "types": ["node"]
+  }
+}

--- a/packages/starknet-rpc/vitest.config.ts
+++ b/packages/starknet-rpc/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    testTimeout: 10000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -730,10 +730,17 @@ importers:
         version: 1.6.1(@types/node@20.19.39)
 
   packages/starknet-rpc:
+    dependencies:
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
     devDependencies:
       '@types/node':
         specifier: ^20.12.13
         version: 20.19.39
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       unbuild:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.9.3)
@@ -2658,6 +2665,9 @@ packages:
 
   '@types/whatwg-url@11.0.5':
     resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@valibot/to-json-schema@1.0.0-beta.4':
     resolution: {integrity: sha512-wXBdCyoqec+NLCl5ihitXzZXD4JAjPK3+HfskSXzfhiNFvKje0A/v1LygqKidUgIbaJtREmq/poJGbaS/0MKuQ==}
@@ -4607,6 +4617,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -6496,6 +6518,10 @@ snapshots:
   '@types/whatwg-url@11.0.5':
     dependencies:
       '@types/webidl-conversions': 7.0.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.39
 
   '@valibot/to-json-schema@1.0.0-beta.4(valibot@1.0.0-beta.12(typescript@5.9.3))':
     dependencies:
@@ -8495,6 +8521,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.3: {}
+
+  ws@8.21.0: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,10 +345,10 @@ importers:
         version: link:../protocol
       '@rollup/plugin-replace':
         specifier: ^6.0.2
-        version: 6.0.3(rollup@4.60.2)
+        version: 6.0.3(rollup@3.30.0)
       '@rollup/plugin-virtual':
         specifier: ^3.0.2
-        version: 3.0.2(rollup@4.60.2)
+        version: 3.0.2(rollup@3.30.0)
       c12:
         specifier: ^1.11.1
         version: 1.11.2
@@ -731,6 +731,9 @@ importers:
 
   packages/starknet-rpc:
     dependencies:
+      '@apibara/protocol':
+        specifier: workspace:*
+        version: link:../protocol
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -6266,16 +6269,16 @@ snapshots:
     optionalDependencies:
       rollup: 3.30.0
 
-  '@rollup/plugin-replace@6.0.3(rollup@4.60.2)':
+  '@rollup/plugin-replace@6.0.3(rollup@3.30.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      '@rollup/pluginutils': 5.3.0(rollup@3.30.0)
       magic-string: 0.30.21
     optionalDependencies:
-      rollup: 4.60.2
+      rollup: 3.30.0
 
-  '@rollup/plugin-virtual@3.0.2(rollup@4.60.2)':
+  '@rollup/plugin-virtual@3.0.2(rollup@3.30.0)':
     optionalDependencies:
-      rollup: 4.60.2
+      rollup: 3.30.0
 
   '@rollup/pluginutils@5.3.0(rollup@3.30.0)':
     dependencies:
@@ -6284,14 +6287,6 @@ snapshots:
       picomatch: 4.0.4
     optionalDependencies:
       rollup: 3.30.0
-
-  '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.4
-    optionalDependencies:
-      rollup: 4.60.2
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,10 +345,10 @@ importers:
         version: link:../protocol
       '@rollup/plugin-replace':
         specifier: ^6.0.2
-        version: 6.0.3(rollup@3.30.0)
+        version: 6.0.3(rollup@4.60.2)
       '@rollup/plugin-virtual':
         specifier: ^3.0.2
-        version: 3.0.2(rollup@3.30.0)
+        version: 3.0.2(rollup@4.60.2)
       c12:
         specifier: ^1.11.1
         version: 1.11.2
@@ -6269,16 +6269,16 @@ snapshots:
     optionalDependencies:
       rollup: 3.30.0
 
-  '@rollup/plugin-replace@6.0.3(rollup@3.30.0)':
+  '@rollup/plugin-replace@6.0.3(rollup@4.60.2)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@3.30.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
       magic-string: 0.30.21
     optionalDependencies:
-      rollup: 3.30.0
+      rollup: 4.60.2
 
-  '@rollup/plugin-virtual@3.0.2(rollup@3.30.0)':
+  '@rollup/plugin-virtual@3.0.2(rollup@4.60.2)':
     optionalDependencies:
-      rollup: 3.30.0
+      rollup: 4.60.2
 
   '@rollup/pluginutils@5.3.0(rollup@3.30.0)':
     dependencies:
@@ -6287,6 +6287,14 @@ snapshots:
       picomatch: 4.0.4
     optionalDependencies:
       rollup: 3.30.0
+
+  '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.2
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,6 +729,18 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)
 
+  packages/starknet-rpc:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.12.13
+        version: 20.19.39
+      unbuild:
+        specifier: ^2.0.0
+        version: 2.0.0(typescript@5.9.3)
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)
+
 packages:
 
   '@adraffy/ens-normalize@1.11.1':


### PR DESCRIPTION
## Summary

  Adds `@apibara/starknet-rpc`, a Starknet JSON-RPC v0.10 event indexing package.

  The package supports accepted historical backfill over HTTP with `starknet_getEvents`, plus live event indexing over WebSocket subscriptions with reconnect handling,
  reorg messages, cursor resume logic, and pre-confirmed indexing by default.

  ## Included

  - HTTP event backfill with continuation tokens, chunking, and configurable range sizing
  - WebSocket live event subscriptions with reconnects, idle timeout, bounded queues, and rollback messages
  - Cursor normalization, finality-aware resume behavior, event deduping, and block metadata caching
  - `StarknetRpcStream`, an Apibara `RpcStreamConfig` adapter for accepted event blocks
  - CLI/runtime support for `RpcStreamConfig` sources without requiring a DNA `streamUrl`
  - README documentation and tests

  ## Notes

  - Historical backfill uses accepted events from `starknet_getEvents`
  - `finalityStatus` applies to live WebSocket subscriptions
  - Callers should persist cursor finality and rollback cursors with application state for correct restart and reorg handling
  - Large backfills should tune `chunkSize`, `getEventsRangeSize`, and node infrastructure according to rate limits

  ## Verification

  - `pnpm --filter @apibara/starknet-rpc lint`
  - `pnpm --filter @apibara/starknet-rpc typecheck`
  - `pnpm --filter @apibara/starknet-rpc test:ci`
  - `pnpm --filter @apibara/starknet-rpc build`
  - `pnpm --filter @apibara/indexer lint`
  - `pnpm --filter @apibara/indexer typecheck`
  - `pnpm --filter @apibara/indexer test:ci`
  - `pnpm --filter @apibara/indexer build`
  - `pnpm --filter apibara lint`
  - `pnpm --filter apibara typecheck`
  - `pnpm --filter apibara build`
  - `pnpm beachball check`